### PR TITLE
fixes DEPRECATION WARNING: The success? predicate is deprecated and w…

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CatalogController, type: :controller do
   describe 'index action' do
     it 'gets search results from the solr index' do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 


### PR DESCRIPTION
…ill be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers.

this warning shows up during rspec execution

very small fix, we're totally ready for Rails 6.0