### PR TITLE
update traject version to 3.0 - closes #138

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'rubocop'
   gem 'solr_wrapper', github: 'cbeer/solr_wrapper', branch: 'master'
   gem 'sqlite3'
-  gem 'traject', '~> 2.3'
+  gem 'traject', '3.0.0'
 end
 
 group :production, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'erb_lint', '0.0.26'
   gem 'niftany'
   gem 'rspec-rails'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
@@ -125,11 +126,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dotenv (2.5.0)
-    erb_lint (0.0.28)
+    erb_lint (0.0.26)
       activesupport
       better_html (~> 1.0.7)
+      colorize
       html_tokenizer
-      rainbow
       rubocop (~> 0.51)
       smart_properties
     erubi (1.7.1)
@@ -367,6 +368,7 @@ DEPENDENCIES
   coveralls
   devise
   devise-guests (~> 0.6)
+  erb_lint (= 0.0.26)
   foreman (~> 0.63.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/projectblacklight/blacklight.git
-  revision: bc8a8b8235e293187eb2adff7ec172cc79f9361f
+  revision: c1ce34f2220af3b08c0ebec86d99991591f66f36
   specs:
     blacklight (7.0.0.rc1)
       deprecation
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/psu-libraries/blacklight-marc.git
-  revision: 48e25602584f1f12d48b5167d189904e2460408f
+  revision: 5737fec70ab310ecfe92045adceef0f34efa11a5
   specs:
     blacklight-marc (7.0.0.alpha)
       blacklight (> 7.0.0.a, < 8.a)
@@ -31,7 +31,7 @@ GIT
       marc (>= 0.4.3, < 1.1)
       marc-fastxmlwriter
       rails
-      traject (~> 2.1)
+      traject (>= 2.1, <= 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -77,9 +77,11 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.1.4)
+    autoprefixer-rails (9.3.0)
       execjs
     bcrypt (3.1.12)
     better_html (1.0.11)
@@ -99,14 +101,13 @@ GEM
       sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
-    colorize (0.8.1)
     concurrent-ruby (1.0.5)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
+    coveralls (0.8.22)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
     crass (1.0.4)
     deprecation (1.0.0)
       activesupport
@@ -124,11 +125,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dotenv (2.5.0)
-    erb_lint (0.0.26)
+    erb_lint (0.0.28)
       activesupport
       better_html (~> 1.0.7)
-      colorize
       html_tokenizer
+      rainbow
       rubocop (~> 0.51)
       smart_properties
     erubi (1.7.1)
@@ -143,8 +144,15 @@ GEM
       activesupport (>= 4.2.0)
     hashie (3.6.0)
     html_tokenizer (0.0.7)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    http-form_data (2.1.1)
+    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
@@ -186,9 +194,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mime-types (3.2.2)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -197,7 +202,6 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mysql2 (0.5.2)
-    netrc (0.11.0)
     niftany (0.2.0)
       erb_lint (~> 0.0.22)
       rubocop (~> 0.51, <= 0.52.1)
@@ -212,6 +216,7 @@ GEM
       ast (~> 2.4.0)
     popper_js (1.14.3)
     powerpack (0.1.2)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
     rack-proxy (0.6.5)
@@ -250,23 +255,19 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     retriable (3.1.2)
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-rails (3.8.0)
+    rspec-rails (3.8.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -318,16 +319,18 @@ GEM
     sqlite3 (1.3.13)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    thor (0.20.0)
+    thor (0.19.4)
     thread_safe (0.3.6)
-    tins (1.16.3)
-    traject (2.3.4)
+    tins (1.17.0)
+    traject (3.0.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
       hashie (~> 3.1)
+      http (~> 3.0)
       httpclient (~> 2.5)
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
+      nokogiri (~> 1.0)
       slop (>= 3.4.5, < 4.0)
       yell
     tzinfo (1.2.5)
@@ -379,9 +382,9 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
-  traject (~> 2.3)
+  traject (= 3.0.0)
   web-console (>= 3.3.0)
   webpacker (~> 3.5)
 
 BUNDLED WITH
-   1.16.5
+   1.16.6


### PR DESCRIPTION

Requires https://github.com/psu-libraries/blacklight-marc/pull/3

Closes #138 