### PR TITLE
#165 docker solr

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ Metrics/BlockLength:
   - 'app/controllers/catalog_controller.rb'
   - 'db/**/*'
   - 'spec/**/*'
+  - 'lib/tasks/**/*'
 
 Metrics/LineLength:
   Exclude:

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,9 +1,0 @@
-# Place any default configuration for solr_wrapper here
-# port: 8983
-version: 7.4.0
-collection:
-  dir: solr/conf/
-  name: blacklight-core
-  persist: true
-instance_dir: tmp/solr/
-download_dir: tmp/solr_dl

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'blacklight-marc', github: 'projectblacklight/blacklight-marc'
 group :development do
   gem 'foreman', '~> 0.63.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'solr_wrapper', github: 'cbeer/solr_wrapper', branch: 'master'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: https://github.com/cbeer/solr_wrapper.git
-  revision: 4c412aba182a33c28fddf77736f86d7c8c304102
-  branch: master
-  specs:
-    solr_wrapper (2.0.0)
-      faraday
-      retriable
-      ruby-progressbar
-      rubyzip
-
-GIT
   remote: https://github.com/projectblacklight/blacklight-marc.git
   revision: 84c0154ebe9ec19524aafc9c8ac779db2189da40
   specs:
@@ -257,7 +246,6 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    retriable (3.1.2)
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -289,7 +277,6 @@ GEM
       rubocop (>= 0.52.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
     sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -380,7 +367,6 @@ DEPENDENCIES
   rsolr (>= 1.0)
   rspec-rails
   rubocop
-  solr_wrapper!
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-solr: bundle exec solr_wrapper
+solr: bundle exec rails docker:up
 web: rails s -p 3000
 webpacker: bin/webpack-dev-server

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -24,7 +24,7 @@ namespace :docker do
     print `docker pull solr:7.4.0`
     print `docker run \
             --name felix \
-            -a \
+            -a STDOUT \
             -p 8983:8983 \
             -v "$(pwd)"/solr/conf:/myconfig \
             solr:7.4.0 \

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :docker do
+  task :up do
+    container_status = `docker inspect felix`
+    container_status.strip!
+
+    if container_status == '[]'
+      Rake::Task['docker:start'].invoke
+    else
+      print `docker start -a felix`
+    end
+
+    Rake::Task['docker:ps'].invoke
+  end
+
+  task :clean do
+    print `docker exec -it felix \
+            post -c blacklight-core \
+                 -d '<delete><query>*:*</query></delete>' -out 'yes'`
+  end
+
+  task :start do
+    print `docker pull solr:7.4.0`
+    print `docker run \
+            --name felix \
+            -a \
+            -p 8983:8983 \
+            -v "$(pwd)"/solr/conf:/myconfig \
+            solr:7.4.0 \
+            solr-create -c blacklight-core -d /myconfig`
+  end
+
+  task :down do
+    print `docker stop felix`
+  end
+
+  task :ps do
+    print `docker ps`
+  end
+end


### PR DESCRIPTION
this removes solr_wrapper entirely and replaces it locally with docker solr.

@banukutlu can you give this a spin locally to test it out before merging? you'll need to download [docker ce for mac](https://store.docker.com/editions/community/docker-ce-desktop-mac), including creating an account. Note that the Procfile is updated too. I think that after you download and install, then checkout this branch you should be able to run our foreman command. After that you'll import using traject as usual.