### PR TITLE
#204 publication fields

### DIFF
--- a/app/presenters/psul_index_presenter.rb
+++ b/app/presenters/psul_index_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PsulIndexPresenter < Blacklight::IndexPresenter
+  def label(field_or_string_or_proc, opts = {})
+    original = super
+    # To hide label for publication statement
+    @configuration.index_fields['publication_display_ssm'].label = nil
+
+    original
+  end
+end

--- a/app/presenters/psul_index_presenter.rb
+++ b/app/presenters/psul_index_presenter.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class PsulIndexPresenter < Blacklight::IndexPresenter
-  def label(field_or_string_or_proc, opts = {})
+  def fields
     original = super
     # To hide label for publication statement
-    @configuration.index_fields['publication_display_ssm'].label = nil
+    configuration.index_fields['publication_display_ssm'].label = nil
 
     original
   end

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,0 +1,14 @@
+<% doc_presenter = index_presenter(document) %>
+<%# default partial to display solr document fields in catalog index view -%>
+<dl class="document-metadata dl-invert row">
+
+  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
+    <% if field[:label].nil? %>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-12"><%= doc_presenter.field_value field %></dd>
+    <% else %>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+    <% end -%>
+  <% end -%>
+
+</dl>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -162,8 +162,10 @@
          language_facet_ssim,
          lc_callnum_display_ssm,
          material_type_display_ssm,
-         published_display_ssm,
-         published_vern_display_ssm,
+         publication_display_ssm
+         overall_imprint_display_ssm,
+         edition_display_ssm,
+         copyright_display_ssm,
          pub_date_ssim,
          title_display_ssm,
          title_latin_display_ssm,

--- a/spec/presenters/psul_index_presenter_spec.rb
+++ b/spec/presenters/psul_index_presenter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PsulIndexPresenter do
+  subject(:presenter) { described_class.new(document, request_context, config) }
+
+  let(:document) { SolrDocument.new }
+  let(:request_context) { instance_double(ActionView::Base, document_index_view_type: 'list') }
+  let(:config) { Blacklight::Configuration.new }
+
+  describe '#label' do
+    context 'when a document has a publication statement' do
+      let(:document) do
+        SolrDocument.new(id: 1,
+                         format: 'Book',
+                         publication_display_ssm: 'This is the publication statement of the document')
+      end
+
+      let(:config) do
+        Blacklight::Configuration.new.configure do |config|
+          config.add_index_field 'publication_display_ssm'
+          config.add_index_field 'format'
+        end
+      end
+
+      it 'publication statement has an empty label' do
+        expect(presenter.fields['publication_display_ssm'].label).to be_nil
+        expect(presenter.fields['format'].label).to eq('Format')
+      end
+    end
+  end
+end

--- a/spec/presenters/psul_index_presenter_spec.rb
+++ b/spec/presenters/psul_index_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PsulIndexPresenter do
         end
       end
 
-      it 'has no label for publication statement, but still has a label for format'
+      it 'has no label for publication statement, but still has a label for format' do
         expect(presenter.fields['publication_display_ssm'].label).to be_nil
         expect(presenter.fields['format'].label).to eq('Format')
       end

--- a/spec/presenters/psul_index_presenter_spec.rb
+++ b/spec/presenters/psul_index_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PsulIndexPresenter do
         end
       end
 
-      it 'publication statement has an empty label' do
+      it 'has no label for publication statement, but still has a label for format'
         expect(presenter.fields['publication_display_ssm'].label).to be_nil
         expect(presenter.fields['format'].label).to eq('Format')
       end


### PR DESCRIPTION
Connected to #204 


- index and display publication fields
- to hide the publication statement label in search results added `psul_index_presenter.rb` and `_index_default.html.erb` partial (there might be a better way to solve this)
- also reordered the single item labels