### PR TITLE
removed facets that are not included in the sidebar display 

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -158,6 +158,7 @@
          issn_sim
        </str>
 
+       <!-- list fields to be displayed in the search results page -->
        <str name="fl">
          id,
          score,
@@ -168,23 +169,20 @@
          full_links_struct
        </str>
 
+       <!-- list fields to be displayed as facets -->
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
        <str name="facet.field">access_facet</str>
-       <str name="facet.field">all_authors_facet</str>
        <str name="facet.field">format</str>
-       <str name="facet.field">language_facet</str>
+       <str name="facet.field">campus_facet</str>
+       <str name="facet.field">up_library_facet</str>
        <str name="facet.field">pub_date_itsi</str>
+       <str name="facet.field">language_facet</str>
        <str name="facet.field">subject_topic_facet</str>
-       <str name="facet.field">subject_facet</str>
        <str name="facet.field">genre_facet</str>
-       <str name="facet.field">genre_full_facet_ssim</str>
        <str name="facet.field">media_type_facet</str>
        <str name="facet.field">lc_1letter_facet</str>
        <str name="facet.field">lc_rest_facet</str>
-       <str name="facet.field">campus_facet</str>
-       <str name="facet.field">up_library_facet</str>
-       <str name="facet.field">library_facet</str>
      </lst>
   </requestHandler>
 


### PR DESCRIPTION
Connected to #251

@cdmo I removed `all_authors_facet `, `subject_facet`,  `genre_full_facet_ssim` and `library_facet ` facets since they are not displayed in the sidebar and reordered the fields. 
Tested on my local, esp for `library_facet` in Advanced Search but pls you also test it. 

