### PR TITLE
Refines robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,9 @@
 User-agent: *
-Crawl-delay: 10
-Sitemap: http://catalog.libraries.psu.edu/sitemap.xml
+Sitemap: https://catalog.libraries.psu.edu/sitemap.xml
 Disallow: /*q=*
 Disallow: /?f*
+Disallow: /catalog?utf8=✓*
 Disallow: /catalog.atom
 Disallow: /catalog.rss
 Disallow: /catalog/*/email
+Disallow: /catalog/*/marc_view


### PR DESCRIPTION
* Removes crawl-delay entirely
* Excludes marc_view
* Excludes pattern /catalog?utf8=✓* (which was appearing in Google Search Console as valid)

(low priority)