### PR TITLE
Resets gem for Blacklight Advanced Search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'webpacker', '~> 4.0'
 
 gem 'blacklight', '~> 7.0'
 gem 'blacklight-marc', '>= 7.0.0.rc1'
-gem 'blacklight_advanced_search', github: 'projectblacklight/blacklight_advanced_search', ref: '9c23f0e9aad6a789ec91233'
+gem 'blacklight_advanced_search', '~> 7.0'
 gem 'blacklight_range_limit', '~> 7.1'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/projectblacklight/blacklight_advanced_search.git
-  revision: 9c23f0e9aad6a789ec912336766289927ea0729b
-  ref: 9c23f0e9aad6a789ec91233
-  specs:
-    blacklight_advanced_search (7.0.0.alpha)
-      blacklight (~> 7.0)
-      parslet
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,6 +74,9 @@ GEM
       marc-fastxmlwriter
       rails
       traject (~> 3.0)
+    blacklight_advanced_search (7.0.0)
+      blacklight (~> 7.0)
+      parslet
     blacklight_range_limit (7.1.0)
       blacklight (>= 7.0)
       rails (>= 3.0)
@@ -381,7 +375,7 @@ DEPENDENCIES
   binding_of_caller
   blacklight (~> 7.0)
   blacklight-marc (>= 7.0.0.rc1)
-  blacklight_advanced_search!
+  blacklight_advanced_search (~> 7.0)
   blacklight_range_limit (~> 7.1)
   bootsnap
   byebug


### PR DESCRIPTION
Now that there's a stable release on rubygems for blacklight advanced search, switching to using rubygems as source.