### PR TITLE
Removes the hathi_links struct from the fields list and instead just …

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,7 +181,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'publication_display_ssm', label: 'Publication Statement', sr_only: true
     config.add_index_field 'edition_display_ssm', label: 'Edition', sr_only: true
     config.add_index_field 'full_links_struct', label: 'Access Online', helper_method: :generic_link
-    config.add_index_field 'hathitrust_struct', label: 'HathiTrust Link', accessor: :hathi_links, helper_method: :hathi_info, sr_only: true
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -197,7 +196,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'phys_desc_ssm', label: 'Physical Description', top_field: true, if: false
     config.add_show_field 'addl_author_display_ssm', label: 'Additional Creators', link_to_facet: :all_authors_facet, top_field: true, if: false
     config.add_show_field 'full_links_struct', label: 'Access Online', top_field: true, helper_method: :generic_link, if: false
-    config.add_show_field 'hathitrust_struct', label: 'HathiTrust Link', top_field: true, accessor: :hathi_links, helper_method: :hathi_info, sr_only: true, if: false
     config.add_show_field 'series_title_display_ssm', label: 'Series'
     config.add_show_field 'language_ssim', label: 'Language'
     config.add_show_field 'language_note_ssm', label: 'Language Note'

--- a/app/models/hathi_links.rb
+++ b/app/models/hathi_links.rb
@@ -1,54 +1,67 @@
 # frozen_string_literal: true
 
-class HathiLinks
-  attr_reader :document
+module HathiLinks
+  def hathi_links
+    return nil unless has_hathi_links?
 
-  def initialize(document)
-    @document = document
-    @ht_hash = ht_hash
+    {
+      text: ht_link_text,
+      url: ht_url,
+      additional_text: ht_additional_text
+    }
   end
 
-  def ht_hash
-    JSON.parse(document['hathitrust_struct']&.first)
-  end
+  private
 
-  def id
-    ht_hash['ht_id']
-  end
+    def has_hathi_links?
+      @_source['hathitrust_struct'].present?
+    end
 
-  def bib_key
-    ht_hash['ht_bib_key']
-  end
+    def hathi_links_field
+      @_source['hathitrust_struct']
+    end
 
-  def access
-    ht_hash['access']
-  end
+    def ht_hash
+      JSON.parse(hathi_links_field&.first)
+    end
 
-  def url
-    url = if id.present?
-            I18n.t('blackcat.hathitrust.mono_url') + id
-          else
-            I18n.t('blackcat.hathitrust.multi_url') + bib_key
-          end
+    def ht_id
+      ht_hash['ht_id']
+    end
 
-    url += I18n.t('blackcat.hathitrust.url_append') if etas_item?
-    url
-  end
+    def ht_bib_key
+      ht_hash['ht_bib_key']
+    end
 
-  def link_text
-    text = I18n.t('blackcat.hathitrust.public_domain_text') if access == 'allow'
-    text = I18n.t('blackcat.hathitrust.restricted_access_text') if access == 'deny' && !Settings&.hathi_etas
-    text = I18n.t('blackcat.hathitrust.etas_text') if etas_item?
-    text
-  end
+    def ht_access
+      ht_hash['access']
+    end
 
-  def additional_text
-    return unless etas_item?
+    def ht_url
+      url = if ht_id.present?
+              I18n.t('blackcat.hathitrust.mono_url') + ht_id
+            else
+              I18n.t('blackcat.hathitrust.multi_url') + ht_bib_key
+            end
 
-    I18n.t('blackcat.hathitrust.etas_additional_text')
-  end
+      url += I18n.t('blackcat.hathitrust.url_append') if etas_item?
+      url
+    end
 
-  def etas_item?
-    access == 'deny' && Settings&.hathi_etas
-  end
+    def ht_link_text
+      I18n.t('blackcat.hathitrust.public_domain_text') if ht_access == 'allow'
+      I18n.t('blackcat.hathitrust.restricted_access_text') if ht_access == 'deny' && !Settings&.hathi_etas
+
+      I18n.t('blackcat.hathitrust.etas_text')
+    end
+
+    def ht_additional_text
+      return nil unless etas_item?
+
+      I18n.t('blackcat.hathitrust.etas_additional_text')
+    end
+
+    def etas_item?
+      ht_access == 'deny' && Settings&.hathi_etas
+    end
 end

--- a/app/models/hathi_links.rb
+++ b/app/models/hathi_links.rb
@@ -52,7 +52,7 @@ module HathiLinks
       I18n.t('blackcat.hathitrust.public_domain_text') if ht_access == 'allow'
       I18n.t('blackcat.hathitrust.restricted_access_text') if ht_access == 'deny' && !Settings&.hathi_etas
 
-      I18n.t('blackcat.hathitrust.etas_text')
+      I18n.t('blackcat.hathitrust.etas_text') if etas_item?
     end
 
     def ht_additional_text

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -2,6 +2,7 @@
 
 class SolrDocument
   include Blacklight::Solr::Document
+  include HathiLinks
 
   # self.unique_key = 'id'
   field_semantics.merge!(
@@ -36,10 +37,4 @@ class SolrDocument
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
-
-  def hathi_links
-    return if self['hathitrust_struct'].nil?
-
-    @hathi_links ||= HathiLinks.new(self)
-  end
 end

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,17 +1,20 @@
 <% doc_presenter = index_presenter(document) %>
-  <ul class="document-metadata dl-invert">
-    <% doc_presenter.fields_to_render.each do |field_name, field| -%>
-        <li class="blacklight-<%= field_name.parameterize -%>">
-          <span class="
-                  <%= 'text-muted' unless field[:sr_only] %>
-                  <%= 'sr-only' if field[:sr_only] %>">
-            <%= render_index_field_label document, field: field_name %>
-          </span>
-          <%= doc_presenter.field_value field %>
-        </li>
-    <% end -%>
-  </ul>
 
-  <div class="blacklight-availability">
-    <%= render partial: 'index_availability', locals: { document: document } unless Settings&.readonly %>
-  </div>
+<ul class="document-metadata dl-invert">
+  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
+      <li class="blacklight-<%= field_name.parameterize -%>">
+        <span class="
+                <%= 'text-muted' unless field[:sr_only] %>
+                <%= 'sr-only' if field[:sr_only] %>">
+          <%= render_index_field_label document, field: field_name %>
+        </span>
+        <%= doc_presenter.field_value field %>
+      </li>
+  <% end -%>
+</ul>
+
+<%= render partial: 'hathitrust/hathi_links', locals: { hathi_links: document.hathi_links } if document.hathi_links %>
+
+<div class="blacklight-availability">
+  <%= render partial: 'index_availability', locals: { document: document } unless Settings&.readonly %>
+</div>

--- a/app/views/hathitrust/_hathi_links.html.erb
+++ b/app/views/hathitrust/_hathi_links.html.erb
@@ -1,0 +1,8 @@
+<div class="bs-callout bs-callout-warning">
+  <h5 class="record-view-only" id="conveying-meaning-to-assistive-technologies">Full Text available online</h5>
+  <p class="record-view-only"><%= hathi_links.dig :additional_text %></p>
+  <p><%= link_to(image_pack_tag('media/psulib_blacklight/images/128px-HathiTrust_logo.svg.png',
+                                alt: 'HathiTrust logo',
+                                class: 'mr-3 d-none d-md-inline') + hathi_links.dig(:text),
+                 hathi_links.dig(:url)) %></p>
+</div>


### PR DESCRIPTION
…renders the hathi_links method that's been included on the SolrDocument

What do you think of this instead? I kinda like it because it keeps all the markup in views and it limits the exposed (i.e. not `private`) methods available - also makes testing easier I think. Just kinda sends the document what it needs.

This is incomplete, I only got it working with one combo at the index view, but the rest should be pretty easy. And the specs.


#595 