### PR TITLE
Adds HathiTrust data to Bento endpoint

### DIFF
--- a/app/controllers/bento_controller.rb
+++ b/app/controllers/bento_controller.rb
@@ -19,6 +19,8 @@ class BentoController < CatalogController
   blacklight_config.configure do |config|
     config.add_facet_fields_to_solr_request = false
     config.add_index_field 'title_display_ssm', label: 'Title'
+    config.add_index_field 'hathitrust_struct', label: 'HathiTrust Link', accessor: 'hathi_links',
+                                                helper_method: 'get_first_only'
     config.default_solr_params = {
       facet: false
     }

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -121,4 +121,8 @@ module CatalogHelper
     details.push "catkey: #{document[:id]}"
     safe_join(details, ' | ')
   end
+
+  def get_first_only(options = {})
+    options[:value].first
+  end
 end

--- a/spec/controllers/bento_controller_spec.rb
+++ b/spec/controllers/bento_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BentoController, type: :controller do
       end
 
       it 'has a meta key with metadata containing total count of results' do
-        expect(json_response['meta']&.dig('pages', 'total_count')).to be(7)
+        expect(json_response['meta']&.dig('pages', 'total_count')).to be(8)
       end
 
       it 'has a data key with 3 results' do

--- a/spec/features/ask_a_librarian_spec.rb
+++ b/spec/features/ask_a_librarian_spec.rb
@@ -19,7 +19,8 @@ RSpec.feature 'Ask a librarian', type: :feature do
       page.assert_selector('h1', text: 'MARC View', wait: 10)
       page.driver.go_back
       page.assert_selector('h1',
-                           text: 'Ethical and Social Issues in the Information Age by Joseph Migga Kizza',
+                           text: 'Ethical and Social Issues in the Information Age [electronic resource] / by Joseph M'\
+                                 'igga Kizza',
                            wait: 10)
       expect(page).to have_css('button[class^="libchat"]', count: 1)
     end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -130,4 +130,14 @@ RSpec.describe CatalogHelper, type: :helper do
       expect(marc_record_details).to include "catkey: #{document[:id]}"
     end
   end
+
+  describe '#get_first_only' do
+    let(:options) { { value: [{ hathidata_struct: [{ text: 'Check out digital copy through HathiTrust',
+                                                     url: 'http://example.com',
+                                                     additional_text: 'By blah blah blah.' }] }] }}
+
+    it 'returns the first value of the value array' do
+      expect(get_first_only(options)).not_to be_a_kind_of Array
+    end
+  end
 end


### PR DESCRIPTION
* Updates fixtures.
* Because hathitrust_struct is multivalued, making a helper to just get first value. An Array that contains a has does not get jsonified well.

#590 

I don't love having to get the first value like this because `hathitrust_struct` is always single valued, but wasn't sure we should change the data structure in Solr or not. If we did then we wouldn't need the helper.