### PR TITLE
Moves matomo_id into config gem management

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -23,7 +23,7 @@
       (function () {
           var u = "https://analytics.libraries.psu.edu/matomo/";
           _paq.push(['setTrackerUrl', u + 'matomo.php']);
-          _paq.push(['setSiteId', <%= ENV.fetch 'MATOMO_ID', 10 %>]);
+          _paq.push(['setSiteId', <%= Settings.matomo_id %>]);
           var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
           g.type = 'text/javascript';
           g.async = true;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,1 +1,2 @@
 hold_button_url: http://cat.libraries.psu.edu/cgi-bin/catredirpg?C=
+matomo_id: 10


### PR DESCRIPTION
Related to https://github.com/psu-libraries/psulib_blacklight_deploy/pull/85

This lets us get away from annoying environment setting details