### PR TITLE
HathiTrust links changed to OCN template

### DIFF
--- a/app/models/hathi_links.rb
+++ b/app/models/hathi_links.rb
@@ -2,7 +2,7 @@
 
 module HathiLinks
   def hathi_links
-    return nil unless has_hathi_links?
+    return nil if ht_access.blank?
 
     {
       text: ht_link_text,
@@ -14,39 +14,14 @@ module HathiLinks
 
   private
 
-    def has_hathi_links?
-      @_source['hathitrust_struct'].present?
-    end
-
-    def hathi_links_field
-      @_source['hathitrust_struct']
-    end
-
-    def ht_hash
-      JSON.parse(hathi_links_field&.first)
-    end
-
-    def ht_id
-      ht_hash['ht_id']
-    end
-
-    def ht_bib_key
-      ht_hash['ht_bib_key']
-    end
-
     def ht_access
-      ht_hash['access']
+      @_source['ht_access_ss']
     end
 
     def ht_url
-      url = if ht_id.present?
-              I18n.t('blackcat.hathitrust.mono_url') + ht_id
-            else
-              I18n.t('blackcat.hathitrust.multi_url') + ht_bib_key
-            end
-
-      url += I18n.t('blackcat.hathitrust.url_append') if etas_item?
-      url
+      ocn = @_source['oclc_number_ssim'].first
+      suffix = etas_item? ? I18n.t('blackcat.hathitrust.url_append') : ''
+      "https://catalog.hathitrust.org/api/volumes/oclc/#{ocn}.html#{suffix}"
     end
 
     def ht_link_text

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -16,7 +16,7 @@
 <%= render partial: 'hathitrust/hathi_links', locals: { hathi_links: document.hathi_links } if document.hathi_links %>
 
 <div class="blacklight-availability">
-  <% unless document.hathi_links && document.hathi_links&.dig(:etas_item) && Settings&.hide_etas_holdings -%>
+  <% unless document.hathi_links && document.hathi_links[:etas_item] && Settings&.hide_etas_holdings -%>
     <%= render partial: 'index_availability', locals: { document: document } unless Settings&.readonly %>
   <% end -%>
 </div>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -17,7 +17,7 @@
 
   </div>
   <% if @document && !Settings&.readonly -%>
-    <% unless @document.hathi_links && @document.hathi_links.dig(:etas_item) && Settings&.hide_etas_holdings -%>
+    <% unless @document.hathi_links && @document.hathi_links[:etas_item] && Settings&.hide_etas_holdings -%>
       <%= render partial: 'show_availability', locals: { document: @document } %>
     <% end -%>
   <% end -%>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -227,7 +227,7 @@
          isbn_valid_ssm,
          oclc_number_ssim,
          lccn_ssim,
-         hathitrust_struct
+         ht_access_ss
        </str>
 
        <!-- list fields to be displayed as facets -->

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Availability', type: :feature do
     end
   end
 
-  describe 'User opens the item page for a record', js: true do
+  describe 'User visits catalog record page', js: true do
     it 'that has holdings to display' do
       visit '/catalog/1839879'
       expect(page).to have_selector 'div[class="availability"][data-keys="1839879"]'
@@ -137,17 +137,17 @@ RSpec.feature 'Availability', type: :feature do
       expect(page).not_to have_selector 'div[class="availability"]'
     end
 
-    context 'when Hathi ETAS is enabled' do
+    context 'when HathiTrust ETAS is enabled' do
       before do
         Settings.hathi_etas = true
       end
 
-      it 'an etas record displays holdings' do
+      it 'an ETAS record displays holdings' do
         visit '/catalog/3753687'
         expect(page).to have_selector 'div[class="availability"][data-keys="3753687"]'
       end
 
-      context 'when hide Hathi ETAS holdings is enabled' do
+      context 'when hide HathiTrust ETAS holdings is enabled' do
         before do
           Settings.hide_etas_holdings = true
         end
@@ -159,7 +159,7 @@ RSpec.feature 'Availability', type: :feature do
       end
     end
 
-    context 'when Hathi ETAS is disabled' do
+    context 'when HathiTrust ETAS is disabled' do
       it 'an etas record displays holdings when there are holdable items' do
         visit '/catalog/3753687'
         expect(page).to have_selector 'div[class="availability"][data-keys="3753687"]'

--- a/spec/models/hathi_links_spec.rb
+++ b/spec/models/hathi_links_spec.rb
@@ -74,18 +74,5 @@ RSpec.describe HathiLinks do
                                     })
       end
     end
-
-    it 'generates a url to the catalog record with the etas text' do
-      document = { 'oclc_number_ssim': ['12345'],
-                   'ht_access_ss': 'allow' }
-      hathi_link = SolrDocument.new(document).hathi_links
-
-      expect(hathi_link).to match({
-                                    text: I18n.t('blackcat.hathitrust.public_domain_text'),
-                                    url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
-                                    additional_text: nil,
-                                    etas_item: false
-                                  })
-    end
   end
 end

--- a/spec/models/hathi_links_spec.rb
+++ b/spec/models/hathi_links_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HathiLinks do
         hathi_link = SolrDocument.new(document).hathi_links
 
         expect(hathi_link).to match({
-                                      text: 'Access digital copy through HathiTrust',
+                                      text: I18n.t('blackcat.hathitrust.public_domain_text'),
                                       url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
                                       additional_text: nil,
                                       etas_item: false

--- a/spec/models/hathi_links_spec.rb
+++ b/spec/models/hathi_links_spec.rb
@@ -3,101 +3,89 @@
 require 'rails_helper'
 
 RSpec.describe HathiLinks do
-  subject(:hathi_links) { SolrDocument.new(document).hathi_links }
+  describe '#hathi_links' do
+    it 'returns nil when there is no Hathi data' do
+      document = { 'oclc_number_ssim': ['12345'] }
+      hathi_link = SolrDocument.new(document).hathi_links
 
-  let(:document) { {} }
-
-  context 'when there is no Hathi data' do
-    it { expect(hathi_links).not_to be_present }
-  end
-
-  context 'when hathi etas is disabled' do
-    before do
-      Settings.hathi_etas = false
+      expect(hathi_link).not_to be_present
     end
 
-    context 'with public domain hathi mono item' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_id":"12345","access":"allow"}'] } }
+    context 'when hathi etas is disabled' do
+      before do
+        Settings.hathi_etas = false
+      end
 
-      it 'generates a url to the checkout page or scan view with the public domain text' do
-        expect(hathi_links).to match({
-                                       text: 'Access digital copy through HathiTrust',
-                                       url: 'https://hdl.handle.net/2027/12345',
-                                       additional_text: nil,
-                                       etas_item: false
-                                     })
+      it 'generates a url with the public domain text when the record access is "allow' do
+        document = { 'oclc_number_ssim': ['12345'],
+                     'ht_access_ss': 'allow' }
+        hathi_link = SolrDocument.new(document).hathi_links
+
+        expect(hathi_link).to match({
+                                      text: 'Access digital copy through HathiTrust',
+                                      url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
+                                      additional_text: nil,
+                                      etas_item: false
+                                    })
+      end
+
+      it 'generates a url with the restricted items text when the record access is "deny"' do
+        document = { 'oclc_number_ssim': ['12345'],
+                     'ht_access_ss': 'deny' }
+        hathi_link = SolrDocument.new(document).hathi_links
+
+        expect(hathi_link).to match({
+                                      text: I18n.t('blackcat.hathitrust.restricted_access_text'),
+                                      url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
+                                      additional_text: nil,
+                                      etas_item: false
+                                    })
       end
     end
 
-    context 'with public domain hathi multi/serial item' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_bib_key":"12345","access":"allow"}'] } }
-
-      it 'generates a url to the catalog record with the public domain text' do
-        expect(hathi_links).to match({
-                                       text: 'Access digital copy through HathiTrust',
-                                       url: 'https://catalog.hathitrust.org/Record/12345',
-                                       additional_text: nil,
-                                       etas_item: false
-                                     })
+    context 'when hathi etas is enabled' do
+      before do
+        Settings.hathi_etas = true
       end
-    end
-
-    context 'with restricted domain items' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_id":"12345","access":"deny"}'] } }
-
-      it 'generates a url with the restricted items text' do
-        expect(hathi_links).to match({
-                                       text: I18n.t('blackcat.hathitrust.restricted_access_text'),
-                                       url: 'https://hdl.handle.net/2027/12345',
-                                       additional_text: nil,
-                                       etas_item: false
-                                     })
-      end
-    end
-  end
-
-  context 'when hathi etas is enabled' do
-    before do
-      Settings.hathi_etas = true
-    end
-
-    context 'with public domain items' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_id":"12345","access":"allow"}'] } }
 
       it 'generates a url with the public domain text' do
-        expect(hathi_links).to match({
-                                       text: I18n.t('blackcat.hathitrust.public_domain_text'),
-                                       url: 'https://hdl.handle.net/2027/12345',
-                                       additional_text: nil,
-                                       etas_item: false
-                                     })
-      end
-    end
+        document = { 'oclc_number_ssim': ['12345'],
+                     'ht_access_ss': 'allow' }
+        hathi_link = SolrDocument.new(document).hathi_links
 
-    context 'with etas mono item' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_id":"12345","access":"deny"}'] } }
+        expect(hathi_link).to match({
+                                      text: I18n.t('blackcat.hathitrust.public_domain_text'),
+                                      url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
+                                      additional_text: nil,
+                                      etas_item: false
+                                    })
+      end
 
       it 'generates a url to the checkout page or scan view with the etas text' do
-        expect(hathi_links).to match({
-                                       text: I18n.t('blackcat.hathitrust.etas_text'),
-                                       url: 'https://hdl.handle.net/2027/12345?urlappend=%3Bsignon=swle:urn:mace:incommon:psu.edu',
-                                       additional_text: I18n.t('blackcat.hathitrust.etas_additional_text'),
-                                       etas_item: true
-                                     })
+        document = { 'oclc_number_ssim': ['12345'],
+                     'ht_access_ss': 'deny' }
+        hathi_link = SolrDocument.new(document).hathi_links
+
+        expect(hathi_link).to match({
+                                      text: I18n.t('blackcat.hathitrust.etas_text'),
+                                      url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html?urlappend=%3Bsignon=swle:urn:mace:incommon:psu.edu',
+                                      additional_text: I18n.t('blackcat.hathitrust.etas_additional_text'),
+                                      etas_item: true
+                                    })
       end
     end
 
-    context 'with etas multi/serial item' do
-      let(:document) { { 'hathitrust_struct': ['{"ht_bib_key":"12345","access":"deny"}'] } }
+    it 'generates a url to the catalog record with the etas text' do
+      document = { 'oclc_number_ssim': ['12345'],
+                   'ht_access_ss': 'allow' }
+      hathi_link = SolrDocument.new(document).hathi_links
 
-      it 'generates a url to the catalog record with the etas text' do
-        expect(hathi_links).to match({
-                                       text: I18n.t('blackcat.hathitrust.etas_text'),
-                                       url: 'https://catalog.hathitrust.org/Record/12345?urlappend=%3Bsignon=swle:urn:mace:incommon:psu.edu',
-                                       additional_text: I18n.t('blackcat.hathitrust.etas_additional_text'),
-                                       etas_item: true
-                                     })
-      end
+      expect(hathi_link).to match({
+                                    text: I18n.t('blackcat.hathitrust.public_domain_text'),
+                                    url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
+                                    additional_text: nil,
+                                    etas_item: false
+                                  })
     end
   end
 end


### PR DESCRIPTION
Will replace the ht struct with a single valued access level field. Requires https://github.com/psu-libraries/psulib_traject/pull/265