### PR TITLE
Availability: Show a message in the UI when an online item is on order

### DIFF
--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -137,6 +137,12 @@ RSpec.feature 'Availability', type: :feature do
       expect(page).not_to have_selector 'div[class="availability"]'
     end
 
+    xit 'that is an online resource and all copies are on order' do
+      visit '/catalog/33183518'
+      expect(page).to have_selector 'div[class="availability"][data-keys="33183518"]'
+      expect(page).to have_selector 'h5', text: /Being acquired by the library/
+    end
+
     context 'when HathiTrust ETAS is enabled' do
       before do
         Settings.hathi_etas = true


### PR DESCRIPTION
Re: #704

When an item is online-only (i.e. NO physical copies available) AND all `currentLocationId` fields for that item are `ON-ORDER`, we now show a message in the UI to indicate that the item is being acquired by the libraries:

<img width="1190" alt="Screen Shot 2021-03-12 at 1 29 52 PM" src="https://user-images.githubusercontent.com/639920/110985623-abe22b00-833a-11eb-97ee-5de2430f3bb8.png">
