### PR TITLE
Fix for <br> tag in<title> for complex faceting

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -51,8 +51,3 @@ en:
     pagination:
       previous: '&larr; Previous'
       next: 'Next &rarr;'
-  support:
-    array:
-      words_connector: "<br>"
-      two_words_connector: "<br>"
-      last_word_connector: "<br>"


### PR DESCRIPTION
Fixes #674.

This commit removes the `support` array from the English translation config file, which was causing `<br>` tags to show up in the `<title>` tag when a user searched using a facet with 2 selected values.

**Before:**
<img width="482" alt="Screen Shot 2021-03-16 at 12 05 05 PM" src="https://user-images.githubusercontent.com/639920/111341417-e0fac000-864f-11eb-945e-29caf4bb5162.png">

**After:**
<img width="494" alt="Screen Shot 2021-03-16 at 12 01 40 PM" src="https://user-images.githubusercontent.com/639920/111341293-c3c5f180-864f-11eb-9f90-6edf2e614b3c.png">
