### PR TITLE
Availability: Fix for constant loading spinners on search results page

### DIFF
--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -50,7 +50,6 @@ const availability = {
         if (titleIDs.length > 0) {
             let allHoldings = [];
             let boundHoldings = [];
-            let isOnlineOnOrderOnly = false;
             const sirsiRequestParams = titleIDs.map(url => '&titleID=' + url).join('');
 
             $.ajax({
@@ -80,7 +79,11 @@ const availability = {
                         }
 
                         // check to see if the item is only available online AND is in ON-ORDER status
-                        isOnlineOnOrderOnly = availability.getIsOnlineOnOrderOnly(titleInfo);
+                        const isOnlineOnOrderOnly = availability.getIsOnlineOnOrderOnly(titleInfo);
+
+                        if (isOnlineOnOrderOnly) {
+                            $(`.availability[data-keys="${catkey}"`).data('isOnlineOnOrderOnly', true);
+                        }
                     });
 
                     if (Object.keys(boundHoldings).length > 0) {
@@ -89,7 +92,7 @@ const availability = {
                     }
                     else {
                         // Print availability data
-                        availability.availabilityDisplay(allHoldings, isOnlineOnOrderOnly);
+                        availability.availabilityDisplay(allHoldings);
                     }
                 }, function() {
                     availability.displayErrorMsg();
@@ -267,10 +270,11 @@ const availability = {
         });
     },
 
-    availabilityDisplay(allHoldings, isOnlineOnOrderOnly) {
+    availabilityDisplay(allHoldings) {
         $('.availability').each(function () {
             const availabilityHTML = $(this);
             const catkey = availabilityHTML.data("keys");
+            const isOnlineOnOrderOnly = availabilityHTML.data('isOnlineOnOrderOnly');
 
             if (catkey in allHoldings) {
                 const rawHoldings = allHoldings[catkey];
@@ -293,7 +297,12 @@ const availability = {
                     }
                 } else if (isOnlineOnOrderOnly) {
                     // only have online copies, but they are in the process of being acquired by the library
-                    holdingsPlaceHolder.html('<h5>Being acquired by the library</h5>');
+                    const beingAcquiredMsg = 'Being acquired by the library';
+
+                    // Document view
+                    holdingsPlaceHolder.html(`<h5>${beingAcquiredMsg}</h5>`);
+                    // Results view
+                    snippetPlaceHolder.parent('.row').html(`<strong>${beingAcquiredMsg}</strong>`);
                 } else {
                     // Document view
                     $('.metadata-availability').remove();

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -60,6 +60,12 @@ RSpec.feature 'Availability', type: :feature do
       expect(page).not_to have_selector '#availability-22091400'
     end
 
+    xit 'that is an online resource and all copies are on order' do
+      visit '/?f[access_facet][]=Online&per_page=10&q=music&search_field=all_fields'
+      expect(page).to have_selector 'div[class="availability"][data-keys="33183518"]'
+      expect(page).to have_selector 'strong', text: /Being acquired by the library/
+    end
+
     context 'when Hathi ETAS is enabled' do
       before do
         Settings.hathi_etas = true


### PR DESCRIPTION
Re: #704

More specifically target individual items in the availability logic so that we can accurately show which items are online + on-order only.

**Search Results View:**
<img width="770" alt="Screen Shot 2021-03-24 at 11 25 25 AM" src="https://user-images.githubusercontent.com/639920/112341673-00b96600-8c98-11eb-9483-6724c48e3528.png">

**Individual Item View:**
<img width="1152" alt="Screen Shot 2021-03-24 at 11 07 32 AM" src="https://user-images.githubusercontent.com/639920/112341707-0747dd80-8c98-11eb-886b-b65c6c9b4350.png">

