### PR TITLE
Advanced Search: Add search button to top of the form

### DIFF
--- a/app/javascript/psulib_blacklight/styles/_advanced_search.scss
+++ b/app/javascript/psulib_blacklight/styles/_advanced_search.scss
@@ -1,0 +1,16 @@
+.advanced-search-form {
+  .submit-buttons {
+    margin: 1rem 0;
+  }
+
+  .submit-buttons-top {
+    float: right;
+
+    @media screen and (max-width: breakpoint-max(md)) {
+      display: block;
+      float: none;
+      margin-bottom: 1rem;
+      margin-top: .5rem;
+    }
+  }
+}

--- a/app/javascript/psulib_blacklight/styles/index.scss
+++ b/app/javascript/psulib_blacklight/styles/index.scss
@@ -48,3 +48,4 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import 'ask_a_librarian';
 @import 'callouts';
 @import 'catalog_index_default';
+@import 'advanced_search';

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,0 +1,50 @@
+<%= form_tag search_catalog_path, class: 'advanced form-horizontal', method: :get do %>
+  <h1 class="advanced page-header">
+    <%= t('blacklight_advanced_search.form.title') %>
+
+    <span class="submit-buttons-top">
+      <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, class: 'btn btn-secondary pull-right advanced-search-start-over' %>
+      <%= submit_tag t('blacklight_advanced_search.form.search_btn'), class: 'btn btn-primary advanced-search-submit', id: 'advanced-search-submit-top' %>
+    </span>
+  </h1>
+
+  <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
+    <div class="constraints well search_history">
+      <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
+      <%= search_context_str %>
+    </div>
+  <% end %>
+
+  <%= render_hash_as_hidden_fields(advanced_search_context) %>
+
+  <div class="input-criteria">
+    <div class="query-criteria">
+      <h3 class="query-criteria-heading">
+        <%= t('blacklight_advanced_search.form.query_criteria_heading_html', select_menu: select_menu_for_field_operator) %>
+      </h3>
+
+      <div id="advanced_search">
+        <%= render 'advanced/advanced_search_fields' %>
+      </div>
+    </div>
+
+    <div class="limit-criteria">
+      <h3 class="limit-criteria-heading"><%= t('blacklight_advanced_search.form.limit_criteria_heading_html') %></h3>
+
+      <div id="advanced_search_facets" class="limit_input">
+        <% if blacklight_config.try(:advanced_search).try {|h| h[:form_facet_partial] } %>
+          <%= render blacklight_config.advanced_search[:form_facet_partial] %>
+        <% else %>
+          <%= render 'advanced_search_facets' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <hr>
+
+  <div class="sort-submit-buttons clearfix">
+    <%= render 'advanced_search_submit_btns' %>
+  </div>
+
+<% end %>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,0 +1,12 @@
+<% @page_title = "More Search Options - #{application_name}" %>
+
+<div class="advanced-search-form col-sm-12">
+  <div class="row">
+    <div class="col-md-8">
+      <%= render 'advanced_search_form' %>
+    </div>
+    <div class="col-md-4">
+      <%= render 'advanced_search_help' %>
+    </div>
+  </div>
+</div>

--- a/spec/views/advanced/_advanced_search_form.html.erb_spec.rb
+++ b/spec/views/advanced/_advanced_search_form.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'advanced/advanced_search_form', type: :view do
+  let(:context) { {} }
+
+  let(:config) { Blacklight::Configuration.new }
+
+  before do
+    stub_template 'advanced/_advanced_search_fields.html.erb' => 'Advanced Search Fields'
+    stub_template 'advanced/_advanced_search_facets.html.erb' => 'Advanced Search Facets'
+    stub_template 'advanced/_advanced_search_submit_btns.html.erb' => 'Advanced Search Submit Buttons'
+  end
+
+  it 'renders an additional search button at the top of the form' do
+    render 'advanced/advanced_search_form', advanced_search_context: context, blacklight_config: config
+
+    expect(rendered).to have_selector 'form h1.page-header input#advanced-search-submit-top'
+  end
+end


### PR DESCRIPTION
Re: #525.

An additional search button has been added to the top of the advanced search form for easier access.

I also increased some vertical margin on the bottom submit buttons to clean up layout a bit.

**Large Screen**
<img width="1137" alt="Screen Shot 2021-03-30 at 2 16 08 PM" src="https://user-images.githubusercontent.com/639920/113036619-8b9bd400-9162-11eb-94bb-a239c58146a2.png">

**Small Screen**
<img width="522" alt="Screen Shot 2021-03-30 at 2 16 22 PM" src="https://user-images.githubusercontent.com/639920/113036667-95253c00-9162-11eb-974e-6813f574bd39.png">

**Spacing Cleanup**
<img width="517" alt="Screen Shot 2021-03-30 at 2 16 27 PM" src="https://user-images.githubusercontent.com/639920/113036684-98b8c300-9162-11eb-9e79-778d14d3c2fd.png">