### PR TITLE
Disable search history

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ Layout/LineLength:
   # The catalog controller is just one giant block for config.
   - 'app/controllers/catalog_controller.rb'
 
+Metrics/ClassLength:
+  Exclude:
+  - 'app/controllers/catalog_controller.rb'
+
 RSpec/MultipleExpectations:
   Exclude:
   # Feature specs are special.

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console', '>= 3.3.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     blacklight (7.10.0)
@@ -433,6 +434,11 @@ GEM
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.8)
       rack (>= 2.0.6)
+    web-console (4.1.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -490,6 +496,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  web-console (>= 3.3.0)
   webdrivers (~> 4.0)
   webmock
   webpacker

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -435,4 +435,11 @@ class CatalogController < ApplicationController
     def trailing_punctuation?
       params[:id].match(/\d+[.,;:!"')\]]/)
     end
+
+    # @note This effectively disables Blacklight's search history feature, which were weren't using. Only the current
+    # search is kept in the session allowing "next" and "previous" links to work; however, any previous searches are
+    # not in the session. While the searches table has to exist, no records will be saved to it.
+    def find_search_session
+      Search.new.tap(&:readonly!)
+    end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# @abstract Blacklight's search model which we use to model a user's search, but not store anything to the database.
+
+class Search < ApplicationRecord
+  belongs_to :user, optional: true
+
+  serialize :query_params
+
+  def saved?
+    false
+  end
+
+  def readonly?
+    true
+  end
+end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Search, type: :model do
+  it { is_expected.not_to be_saved }
+  it { is_expected.to be_readonly }
+end


### PR DESCRIPTION
Blacklight's search session depends on loading recent searches from the Searches table. Completely dropping the table would involve a lot of overriding in `Blacklight::SearchContext`. Additionally, we'd be inheriting some future technical debt whenever we upgraded. 

Instead of getting rid of the table, we disable the search history feature in Blacklight by making the Search model readonly. This allows all of Blacklight to keep on working like nothing's changed, except records are never stored to the database.

A user's session uses a readonly Search record, allowing all of the current behaviors to function, with minimal overrides to Blacklight. An additional override to the Search model ensures that any additional or future attempts to save records will not occur.

Fixes #260 