### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
Changes to licensing required the gem's maintaners to pull old versions. This updates us to the latest, legal version.