### PR TITLE
Add a "Report an Issue" form to catalog records

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -2,6 +2,7 @@
 exclude:
   - '**/node_modules/**/*'
   - '**/vendor/**/*'
+  - '**/app/views/catalog/_report_issue_form.html.erb'
 linters:
   ClosingErbTagIndent:
     enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     blacklight (7.16.0)
@@ -439,6 +440,11 @@ GEM
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-console (4.1.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webdrivers (4.6.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -496,6 +502,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  web-console
   webdrivers (~> 4.0)
   webmock
   webpacker

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,7 @@ class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
+  include ::ReportIssue
 
   def index
     cache_key = nil
@@ -64,11 +65,13 @@ class CatalogController < ApplicationController
   configure_blacklight do |config|
     # Controls the document actions (also called "tools"), note that blacklight_marc adds refworks and endnote
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params, html_class: 'dropdown-item')
+    config.add_show_tools_partial(:report_issue, callback: :report_issue_action, validator: :validate_report_issue_params)
     # TODO: hide SMS action for now, should be enabled when fixed
     # config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params, html_class: 'dropdown-item')
     config.show.document_actions.refworks.html_class = 'dropdown-item'
     config.show.document_actions.endnote.html_class = 'dropdown-item'
     config.show.document_actions.delete_field('librarian_view') # removing something added by blacklight_marc
+    config.show.document_actions.delete_field('report_issue') # hide the 'Report an Issue' action from the Share dropdown
 
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new

--- a/app/controllers/concerns/report_issue.rb
+++ b/app/controllers/concerns/report_issue.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ReportIssue
+  extend ActiveSupport::Concern
+
+  private
+
+    def report_issue_action(_documents)
+      mail = RecordMailer.email_report_issue(title: params[:title],
+                                             record_number: params[:record_number],
+                                             comment: params[:comment],
+                                             email: params[:email])
+
+      if mail.respond_to? :deliver_now
+        mail.deliver_now
+      else
+        mail.deliver
+      end
+
+      flash[:success] = t('blacklight.email.success')
+    end
+
+    def validate_report_issue_params
+      if params[:comment].blank?
+        flash[:error] = t('blackcat.report_issue.errors.comment')
+      end
+
+      flash[:error].blank?
+    end
+end

--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -17,6 +17,15 @@ class RecordMailer < ApplicationMailer
     mail(to: details[:to], subject: subject)
   end
 
+  def email_report_issue(title:, record_number:, comment:, email: '')
+    @title = title
+    @record_number = record_number
+    @comment = comment
+    @email = email
+
+    mail(to: Settings.report_issue_email_recipient, subject: t('blackcat.report_issue.email.subject'))
+  end
+
   def sms_record(documents, details, url_gen_params)
     @documents      = documents
     @url_gen_params = url_gen_params

--- a/app/views/catalog/_record_toolbar.html.erb
+++ b/app/views/catalog/_record_toolbar.html.erb
@@ -1,24 +1,30 @@
 <div class="col record-actions ">
-  <div class="float-right" role="group" aria-label="Actions including with nested dropdown">
-    <%= render_show_doc_actions @document do |config, inner| %>
-      <% if (config.key == :citation) %>
-        <%= inner %>
-      <% end %>
-    <% end %>
-
-    <div class="dropdown">
-      <a class="btn btn-info btn-sm dropdown-toggle" href="#" role="button" id="btnGroupDrop1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share</a>
-      <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
-        <%= render_show_doc_actions @document do |config, inner| %>
-          <% if (config.key != :citation) %>
-            <%= inner %>
-          <% end %>
+  <div class="float-right">
+    <div class="d-inline-block mb-1" role="group" aria-label="Actions including with nested dropdown">
+      <%= render_show_doc_actions @document do |config, inner| %>
+        <% if (config.key == :citation) %>
+          <%= inner %>
         <% end %>
+      <% end %>
+
+      <div class="dropdown">
+        <a class="btn btn-info btn-sm dropdown-toggle" href="#" role="button" id="btnGroupDrop1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share</a>
+        <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+          <%= render_show_doc_actions @document do |config, inner| %>
+            <% if (config.key != :citation) %>
+              <%= inner %>
+            <% end %>
+          <% end %>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="float-right mr-1">
-    <%= render(partial: 'bookmark_control', locals: { document: @document }) %>
+    <div class="d-inline-block mb-1">
+      <%= render(partial: 'bookmark_control', locals: { document: @document }) %>
+    </div>
+
+    <div class="d-inline-block mb-1">
+      <a class="btn btn-sm btn-danger" data-blacklight-modal="trigger" href="<%= request.url %>/report_issue">Report an Issue</a>
+    </div>
   </div>
 </div>

--- a/app/views/catalog/_report_issue_form.html.erb
+++ b/app/views/catalog/_report_issue_form.html.erb
@@ -1,0 +1,59 @@
+<%= form_tag url_for(controller: controller_name, action: "report_issue"),
+             data: { blacklight_modal: 'trigger' },
+             id: 'report_issue_form',
+             class: "modal_form",
+             method: :post do %>
+  <div class="modal-body">
+    <%= render '/shared/flash_msg' %>
+
+    <div class="form-group row">
+      <label class="control-label col-sm-3" for="to">
+        <%= t('blackcat.report_issue.form.record_title') %>
+      </label>
+      <div class="col-sm-9">
+        <%= text_field_tag :title, @documents.first['title_display_ssm'], class: 'form-control', :readonly => true %>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="control-label col-sm-3" for="to">
+        <%= t('blackcat.report_issue.form.record_number') %>
+      </label>
+      <div class="col-sm-9">
+        <%= text_field_tag :record_number, @documents.first.id, class: 'form-control', :readonly => true %>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="control-label col-sm-3" for="message">
+        <%= t('blackcat.report_issue.form.comment') %>
+      </label>
+      <div class="col-sm-9">
+        <%= text_area_tag :comment, params[:comment], class: 'form-control', :required => true %>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="control-label col-sm-3" for="to">
+        <%= t('blackcat.report_issue.form.email') %>
+      </label>
+      <div class="col-sm-9">
+        <%= email_field_tag :email, params[:email], class: 'form-control' %>
+      </div>
+    </div>
+
+    <% @documents&.each do |doc| %>
+      <%=hidden_field_tag "id[]", doc.id %>
+    <% end %>
+    <%- if params[:sort] -%>
+      <%= hidden_field_tag "sort", params[:sort] %>
+    <%- end -%>
+    <%- if params[:per_page] -%>
+      <%= hidden_field_tag "per_page", params[:per_page] %>
+    <%- end -%>
+  </div>
+  
+  <div class="modal-footer">
+    <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
+  </div>
+<% end %>

--- a/app/views/catalog/report_issue.html.erb
+++ b/app/views/catalog/report_issue.html.erb
@@ -1,0 +1,7 @@
+<%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.with(:title, t('blackcat.report_issue.form.title')) %>
+
+  <% component.with(:body) do %>
+    <%= render 'report_issue_form' %>
+  <% end %>
+<% end %>

--- a/app/views/catalog/report_issue_success.html.erb
+++ b/app/views/catalog/report_issue_success.html.erb
@@ -1,0 +1,6 @@
+<%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.with(:title, t('blacklight.email.success')) %>
+
+  <%= render partial: '/shared/flash_msg' %>
+  <span data-blacklight-modal="close"></span>
+<% end %>

--- a/app/views/record_mailer/email_report_issue.text.erb
+++ b/app/views/record_mailer/email_report_issue.text.erb
@@ -1,0 +1,14 @@
+<%= t('blackcat.report_issue.email.subject') %>
+
+<% unless @email.blank? %>
+<%= t('blackcat.report_issue.email.email', email: @email) %>
+
+<% end %>
+<%= t('blackcat.report_issue.email.title', title: @title) %>
+
+<%= t('blackcat.report_issue.email.record_number', record_number: @record_number) %>
+
+<%= t('blackcat.report_issue.email.record_url', record_number: @record_number) %>
+
+<%= t('blackcat.report_issue.email.comment') %>
+<%= @comment %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,19 @@ en:
         restricted_access_text: 'Search inside at HathiTrust'
         etas_text: 'Check out digital copy through HathiTrust'
         etas_additional_text: 'By special arrangement in response to the COVID-19 pandemic, patrons may access this resource online through the HathiTrust Emergency Temporary Access Service.'
+      report_issue:
+        form:
+          title: 'Report an Issue'
+          record_title: 'Title'
+          record_number: 'Record Number'
+          comment: 'Comment (required)'
+          email: 'Email Address (optional, if you''d like a reply)'
+        email:
+          subject: 'Penn State University Libraries Catalog - Issue Report'
+          title: 'Title: %{title}'
+          record_number: 'Record Number: %{record_number}'
+          record_url: 'Record URL: https://catalog.libraries.psu.edu/catalog/%{record_number}'
+          comment: 'Comment:'
+          email: 'Email Address: %{email}'
+        errors:
+          comment: 'Please enter a comment'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
 
   devise_for :users
 
+  match '/catalog/:id/report_issue' => 'catalog#report_issue', via: [:get, :post], as: 'report_issue_solr_document'
+
   # error pages
   match '/404' => 'errors#not_found', via: :all
   match '/422' => 'errors#not_found', via: :all

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 hold_button_url: http://cat.libraries.psu.edu/cgi-bin/catredirpg?C=
 matomo_id: 10
+report_issue_email_recipient: test@test.com
 solr:
   url: http://127.0.0.1:8983
   collection: psul_catalog

--- a/spec/models/record_mailer_spec.rb
+++ b/spec/models/record_mailer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecordMailer do
+  before do
+    allow(described_class).to receive(:default).and_return(from: 'no-reply@libraries.psu.edu')
+  end
+
+  describe 'report_issue' do
+    before do
+      @email = described_class.email_report_issue(title: 'My Book',
+                                                  record_number: 123,
+                                                  comment: 'Some comments',
+                                                  email: 'test@test.com')
+    end
+
+    it 'receives the TO paramater and send the email to that address' do
+      expect(@email.to).to include 'test@test.com'
+    end
+
+    it 'has the correct subject' do
+      expect(@email.subject).to match /Penn State University Libraries Catalog - Issue Report/
+    end
+
+    it 'has the correct from address (w/o the port number)' do
+      expect(@email.from).to include 'no-reply@libraries.psu.edu'
+    end
+
+    it 'prints out the correct body' do
+      expect(@email.body).to match /Penn State University Libraries Catalog - Issue Report/
+      expect(@email.body).to match /Title: My Book/
+      expect(@email.body).to match /Record Number: 123/
+      expect(@email.body).to match /Record URL: https:\/\/catalog.libraries.psu.edu\/catalog\/123/
+      expect(@email.body).to match /Email Address: test@test.com/
+    end
+
+    context 'when the email field is not provided' do
+      email = described_class.email_report_issue(title: 'My Book',
+                                                 record_number: 123,
+                                                 comment: 'Some comments')
+
+      it 'does not contain an email field in the body' do
+        expect(email.body).not_to match /Email Address:/
+      end
+    end
+  end
+end


### PR DESCRIPTION
Re: #720.

This PR adds a "Report an Issue" button to the record toolbar. When clicked, a modal appears, showing a form that a user can fill out to report an issue. An email is then sent to `report_issue_email_recipient` (which in production + QA, should be `catalog-record-issue@PennStateOffice365.onmicrosoft.com`).


### Example Email 
> Penn State University Libraries Catalog - Issue Report
> 
> Email Address: njt5010@psu.edu
> 
> Title: Natural Disaster Housing Reform Act of 2006 : report (to accompany H.R. 5393) (including cost estimate of the Congressional Budget Office).
> 
> Record Number: 3500414
> 
> Comment:
> Something is wrong. Help!

### New Button
<img width="1158" alt="Screen Shot 2021-04-30 at 11 28 36 AM" src="https://user-images.githubusercontent.com/639920/116718226-bcf90100-a9a7-11eb-93fd-0bc1d2e395e5.png">

### Report an Issue Form/Modal
<img width="837" alt="Screen Shot 2021-04-30 at 11 29 04 AM" src="https://user-images.githubusercontent.com/639920/116718255-c5513c00-a9a7-11eb-94e6-c6c81408e3e8.png">

### Form Submission Success
<img width="1160" alt="Screen Shot 2021-04-30 at 11 29 14 AM" src="https://user-images.githubusercontent.com/639920/116718277-cd10e080-a9a7-11eb-8101-173f563b128e.png">
