### PR TITLE
Improve checks for PSU Digital Collections links URLs

### DIFF
--- a/app/models/external_links.rb
+++ b/app/models/external_links.rb
@@ -31,7 +31,13 @@ module ExternalLinks
     end
 
     def digital_collections_link?(link)
-      link['url'].include? 'libraries.psu.edu'
+      matching_urls = [
+        'digital.libraries.psu.edu',
+        'libraries.psu.edu/collections',
+        /collection.+\.libraries\.psu\.edu/
+      ]
+
+      link['url'].match? Regexp.union(matching_urls)
     end
 
     def link_prefix(link)

--- a/spec/models/external_links_spec.rb
+++ b/spec/models/external_links_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 RSpec.describe ExternalLinks do
   describe '#psu_digital_collections_links' do
-    it 'returns nil for psu_digital_collections_links when there is no PSU data' do
+    it 'returns nil for psu_digital_collections_links when there is no PSU Digital Collections data' do
       document = { 'full_links_struct': [
         '{"text":"purl.access.gpo.gov","url":"http://purl.access.gpo.gov/GPO/LPS73013"}',
-        '{"text":"purl.access.gpo.gov","url":"http://purl.access.gpo.gov/GPO/LPS73014"}'
+        '{"text":"purl.access.gpo.gov","url":"http://purl.access.gpo.gov/GPO/LPS73014"}',
+        '{"text":"resources.libraries.psu.edu","url":"http://resources.libraries.psu.edu/findingaids/2789.htm"}'
       ] }
 
       psu_digital_collections_links = SolrDocument.new(document).psu_digital_collections_links
@@ -15,12 +16,13 @@ RSpec.describe ExternalLinks do
       expect(psu_digital_collections_links).not_to be_present
     end
 
-    it 'returns a list of psu_digital_collections_links when there is PSU data' do
+    it 'returns a list of psu_digital_collections_links when there is PSU Digital Collections data' do
       document = { 'full_links_struct': [
         '{"text":"purl.access.gpo.gov","url":"http://purl.access.gpo.gov/GPO/LPS73013"}',
         '{"text":"purl.access.gpo.gov","url":"http://purl.access.gpo.gov/GPO/LPS73014"}',
         '{"text":"digital.libraries.psu.edu","url":"https://digital.libraries.psu.edu/digital/collection/test"}',
-        '{"text":"libraries.psu.edu/collections","url":"https://libraries.psu.edu/collections/test"}'
+        '{"text":"libraries.psu.edu/collections","url":"https://libraries.psu.edu/collections/test"}',
+        '{"text":"collection1.libraries.psu.edu","url":"https://collection1.libraries.psu.edu/test"}'
       ] }
 
       psu_digital_collections_links = SolrDocument.new(document).psu_digital_collections_links
@@ -34,6 +36,11 @@ RSpec.describe ExternalLinks do
         prefix: nil,
         text: 'libraries.psu.edu/collections',
         url: 'https://libraries.psu.edu/collections/test',
+        notes: nil
+      }.with_indifferent_access, {
+        prefix: nil,
+        text: 'collection1.libraries.psu.edu',
+        url: 'https://collection1.libraries.psu.edu/test',
         notes: nil
       }.with_indifferent_access])
     end


### PR DESCRIPTION
Re: #672.

Tightens up our checks for which content is actually part of PSU Digital Collections.

Content is part of PSU Digital Collections if it contains one of the following URLs:

- digital.libraries.psu.edu
- libraries.psu.edu/collections
- collection[x].libraries.psu.edu