### PR TITLE
External Links: trim trailing colon from 'notes' field

### DIFF
--- a/app/models/external_links.rb
+++ b/app/models/external_links.rb
@@ -39,6 +39,6 @@ module ExternalLinks
     end
 
     def link_notes(link)
-      ", #{link['notes']}" if link['notes'].present?
+      ", #{link['notes'].chomp(':')}" if link['notes'].present?
     end
 end

--- a/spec/models/external_links_spec.rb
+++ b/spec/models/external_links_spec.rb
@@ -61,6 +61,37 @@ RSpec.describe ExternalLinks do
     end
   end
 
+  it 'can trim the trailing colon from the prefix and notes if present' do
+    document = { 'full_links_struct': [
+      '{
+        "prefix":"Prefix:",
+        "text":"digital.libraries.psu.edu",
+        "url":"https://digital.libraries.psu.edu/digital/collection/test",
+        "notes":"Note:"
+      }',
+      '{
+        "prefix":"Prefix",
+        "text":"digital.libraries.psu.edu",
+        "url":"https://digital.libraries.psu.edu/digital/collection/test",
+        "notes":"Note"
+      }'
+    ] }
+
+    psu_digital_collections_links = SolrDocument.new(document).psu_digital_collections_links
+
+    expect(psu_digital_collections_links).to match([{
+      prefix: 'Prefix: ',
+      text: 'digital.libraries.psu.edu',
+      url: 'https://digital.libraries.psu.edu/digital/collection/test',
+      notes: ', Note'
+    }.with_indifferent_access, {
+      prefix: 'Prefix: ',
+      text: 'digital.libraries.psu.edu',
+      url: 'https://digital.libraries.psu.edu/digital/collection/test',
+      notes: ', Note'
+    }.with_indifferent_access])
+  end
+
   describe '#access_online_links' do
     it 'returns nil for access_online_links when there is no external (non-PSU) access online data' do
       document = { 'full_links_struct': [


### PR DESCRIPTION
Re: #736.

Any trailing colons on the notes field are now trimmed if present.

### Before:
<img width="983" alt="Screen Shot 2021-05-13 at 3 09 45 PM" src="https://user-images.githubusercontent.com/639920/118174868-5ccd7a80-b3fd-11eb-964b-a4c9e16d54bb.png">

### After:
<img width="985" alt="Screen Shot 2021-05-13 at 3 09 52 PM" src="https://user-images.githubusercontent.com/639920/118174887-60f99800-b3fd-11eb-9fc0-a42a52ad6665.png">