### PR TITLE
Add icon for Microfilm/Microfiche format

### DIFF
--- a/app/javascript/psulib_blacklight/styles/_psulib_icons.scss
+++ b/app/javascript/psulib_blacklight/styles/_psulib_icons.scss
@@ -129,3 +129,8 @@
 .faspsu-other::before {
   content: fa-content($fa-var-scroll);
 }
+
+.blacklight-microfilm-microfiche .blacklight-format::before,
+.faspsu-microfilm-microfiche::before {
+  content: fa-content($fa-var-film);
+}


### PR DESCRIPTION
## Examples

These are 'faked' locally, but should be what it looks like once `Microfilm/Microfiche` is a format

Fixes #749

![Screen Shot 2021-06-03 at 2 32 36 PM](https://user-images.githubusercontent.com/312085/120694924-bbc06580-c478-11eb-9ef6-042d70251d02.png)
![Screen Shot 2021-06-03 at 2 32 10 PM](https://user-images.githubusercontent.com/312085/120694925-bbc06580-c478-11eb-93c5-c574123c70c8.png)
