### PR TITLE
Add tooltips to the "Online" and "Free to Read" facet items

### DIFF
--- a/app/components/psul_facet_item_component.rb
+++ b/app/components/psul_facet_item_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class PsulFacetItemComponent < Blacklight::FacetItemComponent
+  def initialize(psul_facet_item:, wrapping_element: 'li', suppress_link: false)
+    super(facet_item: psul_facet_item, wrapping_element: wrapping_element, suppress_link: suppress_link)
+  end
+
+  ##
+  # Standard display of a facet value in a list. Used in both _facets sidebar
+  # partial and catalog/facet expanded list. Will output facet value name as
+  # a link to add that to your restrictions, with count in parens.
+  #
+  # @return [String]
+  # @private
+  def render_facet_value
+    tag.span(class: 'facet-label') do
+      link_to_unless(@suppress_link, @label, @href, class: 'facet-select', title: facet_tooltip(@label))
+    end + render_facet_count
+  end
+
+  ##
+  # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
+  # @see #render_facet_value
+  #
+  # @private
+  def render_selected_facet_value
+    tag.span(class: 'facet-label') do
+      tag.span(@label, class: 'selected', title: facet_tooltip(@label)) +
+        # remove link
+        link_to(@href, class: 'remove') do
+          tag.span('✖', class: 'remove-icon', aria: { hidden: true }) +
+            tag.span(@view_context.t(:'blacklight.search.facets.selected.remove'), class: 'sr-only')
+        end
+    end + render_facet_count(classes: ['selected'])
+  end
+
+  private
+
+    def facet_tooltip(key)
+      FACET_TOOLTIPS.dig(@facet_item.facet_field, key)
+    end
+
+    FACET_TOOLTIPS = {
+      'access_facet' => {
+        'Free to Read' => I18n.t('blackcat.facet_tooltips.access_facet.free_to_read'),
+        'Online' => I18n.t('blackcat.facet_tooltips.access_facet.online')
+      }
+    }.freeze
+end

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -55,4 +55,9 @@ module FacetsHelper
     pivot.each { |field| in_params = true if params[:f] && params[:f][field] }
     in_params
   end
+
+  def facet_item_component_class(facet_config)
+    default_component = facet_config.pivot ? Blacklight::FacetItemPivotComponent : PsulFacetItemComponent
+    facet_config.fetch(:item_component, default_component)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,10 @@ en:
         restricted_access_text: 'Search inside at HathiTrust'
         etas_text: 'Check out digital copy through HathiTrust'
         etas_additional_text: 'By special arrangement in response to the COVID-19 pandemic, patrons may access this resource online through the HathiTrust Emergency Temporary Access Service.'
+      facet_tooltips:
+        access_facet:
+          free_to_read: 'These materials don''t require a Penn State login'
+          online: 'These materials may require a Penn State login'
       report_issue:
         form:
           title: 'Report an Issue'

--- a/spec/components/psul_facet_item_component_spec.rb
+++ b/spec/components/psul_facet_item_component_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PsulFacetItemComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(psul_facet_item: facet_item)) }
+  let(:selected_span) { rendered.css('span.selected').first }
+  let(:link) { rendered.css('a.facet-select').first }
+
+  context 'when the facet item has a tooltip' do
+    context 'when the facet item is selected' do
+      let(:facet_item) do
+        instance_double(
+          Blacklight::FacetItemPresenter,
+          facet_config: Blacklight::Configuration::FacetField.new,
+          facet_field: 'access_facet',
+          label: 'Online',
+          hits: 10,
+          href: '/catalog?f=x',
+          selected?: true
+        )
+      end
+
+      specify do
+        expect(link).to be_nil
+        expect(selected_span.text).to eq('Online')
+        expect(selected_span.attributes['title'].value).to eq(I18n.t('blackcat.facet_tooltips.access_facet.online'))
+      end
+    end
+
+    context 'when the facet item is unselected' do
+      let(:facet_item) do
+        instance_double(
+          Blacklight::FacetItemPresenter,
+          facet_config: Blacklight::Configuration::FacetField.new,
+          facet_field: 'access_facet',
+          label: 'Online',
+          hits: 10,
+          href: '/catalog?f=x',
+          selected?: false
+        )
+      end
+
+      specify do
+        expect(selected_span).to be_nil
+        expect(link.text).to eq('Online')
+        expect(link.attributes['title'].value).to eq(I18n.t('blackcat.facet_tooltips.access_facet.online'))
+      end
+    end
+  end
+
+  context 'when the facet item does not have a tooltip' do
+    context 'when the facet item is selected' do
+      let(:facet_item) do
+        instance_double(
+          Blacklight::FacetItemPresenter,
+          facet_config: Blacklight::Configuration::FacetField.new,
+          facet_field: 'access_facet',
+          label: 'In the Library',
+          hits: 10,
+          href: '/catalog?f=x',
+          selected?: true
+        )
+      end
+
+      specify do
+        expect(link).to be_nil
+        expect(selected_span.text).to eq('In the Library')
+        expect(selected_span.attributes['title']).to be_nil
+      end
+    end
+
+    context 'when the facet item is unselected' do
+      let(:facet_item) do
+        instance_double(
+          Blacklight::FacetItemPresenter,
+          facet_config: Blacklight::Configuration::FacetField.new,
+          facet_field: 'access_facet',
+          label: 'In the Library',
+          hits: 10,
+          href: '/catalog?f=x',
+          selected?: false
+        )
+      end
+
+      specify do
+        expect(selected_span).to be_nil
+        expect(link.text).to eq('In the Library')
+        expect(link.attributes['title']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Re: #696.

Tooltips (via the HTML `title` attribute) will now appear for "Online" and "Free to Read" facet items. This PR makes it easy to add new tooltips to other facet items by adding new elements to the `FACET_TOOLTIPS` hash.

<img width="378" alt="Screen Shot 2021-06-08 at 10 34 39 AM" src="https://user-images.githubusercontent.com/639920/121204792-268cea80-c845-11eb-9593-d28f97ed207e.png">
