### PR TITLE
Add redis to Procfile

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 solr: bundle exec rails solr:up
 web: rails s -p 3000
 webpacker: bin/webpack-dev-server
+redis: redis-server


### PR DESCRIPTION
This will start Redis along with the other services when the Procfile is used for development. Eventually this will probably go away when we start using Docker, but it's handy for now. 