### PR TITLE
Availability: Add public note tooltip

### DIFF
--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -121,6 +121,7 @@ const availability = {
                     const reserveCollectionID =  $(this).children("reserveCollectionID").text();
                     const reserveCirculationRule = $(this).children("reserveCirculationRule").text();
                     const dueDate = $(this).children("dueDate").text();
+                    const publicNote = $(this).children("publicNote").text();
 
                     allHoldings[titleInfo.catkey].push({
                         catkey: titleInfo.catkey,
@@ -134,7 +135,8 @@ const availability = {
                         holdable: titleInfo.holdable,
                         reserveCollectionID: reserveCollectionID,
                         reserveCirculationRule: reserveCirculationRule,
-                        dueDate: dueDate
+                        dueDate: dueDate,
+                        publicNote: publicNote
                     });
                 });
             }
@@ -323,6 +325,9 @@ const availability = {
         // Check for ILL and Aeon options and update links
         availability.createILLURL();
         availability.createAeonURL();
+
+        // initialize tooltips
+        $('i.fas.fa-info-circle[data-toggle="tooltip"]').tooltip();
     },
 
     printAvailabilityData(availabilityData) {
@@ -351,7 +356,8 @@ const availability = {
                                     <tbody>
                                         ${holdings.map(holding => `
                                             <tr>
-                                                <td>${availability.generateCallNumber(holding)}</td>
+                                                <td>${availability.generateCallNumber(holding)}
+                                                    ${availability.appendPublicNoteTooltip(holding)}</td>
                                                 <td>${holding.itemType}</td>
                                                 <td>${availability.generateLocationHTML(holding)}
                                                     ${availability.appendCourseReserveDueDate(holding)}
@@ -559,6 +565,18 @@ const availability = {
             const circulationRule = availability.reserveCirculationRules[holding.reserveCirculationRule];
 
             return `<br><strong>Due back at:</strong> ${time} on ${day}<br>${circulationRule}`;
+        }
+
+        return '';
+    },
+
+    appendPublicNoteTooltip(holding) {
+        if (holding.publicNote) {
+            return `<i 
+                        class="fas fa-info-circle" 
+                        data-toggle="tooltip" 
+                        data-placement="right" 
+                        title="${holding.publicNote}"></i>`;
         }
 
         return '';

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -66,6 +66,18 @@ RSpec.feature 'Availability', type: :feature do
       expect(page).to have_selector 'strong', text: /Being acquired by the library/
     end
 
+    xit 'that has a public note' do
+      visit '/?utf8=✓&search_field=all_fields&q=6962697'
+      click_button('View Availability')
+      expect(page).to have_selector 'i.fa-info-circle[data-toggle="tooltip"][data-original-title="Struwwelpeter"]'
+    end
+
+    xit 'that does NOT have a public note' do
+      visit '/?utf8=✓&search_field=all_fields&q=2422046'
+      click_button('View Availability')
+      expect(page).not_to have_selector 'i.fa-info-circle[data-toggle="tooltip"]'
+    end
+
     context 'when Hathi ETAS is enabled' do
       before do
         Settings.hathi_etas = true
@@ -147,6 +159,16 @@ RSpec.feature 'Availability', type: :feature do
       visit '/catalog/33183518'
       expect(page).to have_selector 'div[class="availability"][data-keys="33183518"]'
       expect(page).to have_selector 'h5', text: /Being acquired by the library/
+    end
+
+    xit 'that has a public note' do
+      visit '/catalog/6962697'
+      expect(page).to have_selector 'i.fa-info-circle[data-toggle="tooltip"][data-original-title="Struwwelpeter"]'
+    end
+
+    xit 'that does NOT have a public note' do
+      visit '/?utf8=✓&search_field=all_fields&q=2422046'
+      expect(page).not_to have_selector 'i.fa-info-circle[data-toggle="tooltip"]'
     end
 
     xit 'that has an item on course reserve' do


### PR DESCRIPTION
Re: #740.

For items which have a `publicNote`, we now display an info icon with a tooltip.

<img width="538" alt="image" src="https://user-images.githubusercontent.com/639920/121532604-80b8b780-c9cd-11eb-9ab7-771e99218595.png">
