### PR TITLE
Silence deprecation warnings in production

### DIFF
--- a/config/initializers/deprecation_silencers.rb
+++ b/config/initializers/deprecation_silencers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Silence deprecation warnings made in the deprecation gem and in active-support
+
+if ENV['RAILS_ENV'] == 'production'
+  Deprecation.default_deprecation_behavior = :silence
+  ActiveSupport::Deprecation.behavior = [:silence]
+end


### PR DESCRIPTION
These are clogging up our logs and only really need to be displayed for testing and development.