### PR TITLE
Test fixes

### DIFF
--- a/app/models/search_history.rb
+++ b/app/models/search_history.rb
@@ -26,7 +26,7 @@ class SearchHistory
   attr_reader :id
 
   # @param id [String]
-  def initialize(id: id)
+  def initialize(id:)
     @id = generate_id(id)
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Allow any custom host names in development only!
+  config.hosts.clear
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -4,10 +4,7 @@ require 'rails_helper'
 require 'support/vcr'
 
 RSpec.feature 'Availability', :vcr, type: :feature do
-  let (:stubbed_controller) { CatalogController.new }
-
   before do
-    allow(CatalogController).to receive(:new).and_return(stubbed_controller)
     Settings.hathi_etas = false
     Settings.readonly = false
     Settings.hide_hold_button = false

--- a/spec/lib/psulib_blacklight/solr_manager_spec.rb
+++ b/spec/lib/psulib_blacklight/solr_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PsulibBlacklight::SolrManager do
   let(:config_obj) { PsulibBlacklight::SolrConfig.new }
 
   before do
-    stub_request(:any, /:8983/).to_rack(FakeSolr)
+    stub_request(:any, /:#{Settings.solr.port}/).to_rack(FakeSolr)
     stub_const('PsulibBlacklight::SolrManager::ALLOWED_TIME_TO_RESPOND', 1)
   end
 

--- a/spec/models/search_history_spec.rb
+++ b/spec/models/search_history_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SearchHistory, type: :model, redis: true do
   end
 
   describe '#add' do
-    let(:history) { described_class.new }
+    let(:history) { described_class.new(id: session_id) }
 
     context 'when the number of searches is below the limit' do
       it 'adds the search id and sets the expiration value' do


### PR DESCRIPTION
Removes stubbing from availability_spec.rb because it's a feature test. Also corrects a syntax error in search_history.rb which will cause failures once move to Ruby 2.7.