### PR TITLE
Remove the HathiTrust box from search results

### DIFF
--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -24,7 +24,11 @@
       <% end -%>
     </ul>
 
-    <%= render partial: 'external_links/all', locals: { document: document } %>
+    <%= render partial: 'external_links/all',
+               locals: {
+                 document: document,
+                 show_hathi_links: document.hathi_links && document.hathi_links[:etas_item]
+               } %>
   </div>
 </div>
 

--- a/app/views/catalog/_show_top_fields.html.erb
+++ b/app/views/catalog/_show_top_fields.html.erb
@@ -13,4 +13,4 @@
   <% end %>
 </dl>
 
-<%= render partial: 'external_links/all', locals: { document: document } %>
+<%= render partial: 'external_links/all', locals: { document: document, show_hathi_links: true } %>

--- a/app/views/external_links/_all.html.erb
+++ b/app/views/external_links/_all.html.erb
@@ -6,4 +6,4 @@
 
 <%= render partial: 'external_links/access_online_links', locals: { access_online_links: access_online_links } if access_online_links.present? %>
 
-<%= render partial: 'external_links/hathi_links', locals: { hathi_links: document.hathi_links } if hathi_links %>
+<%= render partial: 'external_links/hathi_links', locals: { hathi_links: hathi_links } if hathi_links && show_hathi_links %>

--- a/spec/views/external_links/_all.html.erb_spec.rb
+++ b/spec/views/external_links/_all.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'external_links/all', type: :view do
+  let(:document) { SolrDocument.new(
+    {
+      'oclc_number_ssim': ['12345'],
+      'ht_access_ss': 'allow'
+    }
+  )}
+
+  it 'renders Hathi links when present and show_hathi_links is true' do
+    render 'external_links/all', document: document, show_hathi_links: true
+
+    expect(rendered).to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
+      .and have_css("img[src*='HathiTrust_logo']")
+      .and include(I18n.t('blackcat.hathitrust.public_domain_text'))
+  end
+
+  it 'does not render Hathi links when show_hathi_links is false' do
+    render 'external_links/all', document: document, show_hathi_links: false
+
+    expect(rendered).not_to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
+    expect(rendered).not_to have_css("img[src*='HathiTrust_logo']")
+    expect(rendered).not_to include(I18n.t('blackcat.hathitrust.public_domain_text'))
+  end
+end


### PR DESCRIPTION
Re: #780.

The HathiTrust box will still be shown in the individual item view.