### PR TITLE
only create alias if we're creating the inital collection

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -17,8 +17,6 @@ bundle exec rails db:migrate
 
 echo "initalizing solr"
 bundle exec rake solr:initialize_collection
-bundle exec rake solr:update_config
-bundle exec rake solr:create_alias
 
 echo "starting rails"
 

--- a/lib/psulib_blacklight/solr_manager.rb
+++ b/lib/psulib_blacklight/solr_manager.rb
@@ -59,8 +59,13 @@ module PsulibBlacklight
       if next_collection_version == 1
         puts "creating collection #{next_collection_version}"
         create_collection
+        @update_config ||= modify_collection
+        create_alias
       else
         puts 'collection exists skipping.'
+        @update_config ||= modify_collection
+        # Return nil to indicate we didn't create a collection
+        nil
       end
     end
 

--- a/lib/psulib_blacklight/solr_manager.rb
+++ b/lib/psulib_blacklight/solr_manager.rb
@@ -62,10 +62,8 @@ module PsulibBlacklight
         @update_config ||= modify_collection
         create_alias
       else
-        puts 'collection exists skipping.'
         @update_config ||= modify_collection
-        # Return nil to indicate we didn't create a collection
-        nil
+        puts 'collection exists skipping.'
       end
     end
 

--- a/spec/lib/psulib_blacklight/solr_manager_spec.rb
+++ b/spec/lib/psulib_blacklight/solr_manager_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe PsulibBlacklight::SolrManager do
     context 'when collection does not exist' do
       before do
         stub_request(:get, "#{config_obj.url}/solr/admin/collections?action=LIST")
-          .to_return(status: 200, body: '{"responseHeader":{"status":0, "QTime":11}, "collections":[""]}')
+          .to_return(status: 200, body: '{"responseHeader":{"status":0, "QTime":11}, "collections":[""]}').then
+          .to_return(status: 200, body: '{"responseHeader":{"status":0, "QTime":11},
+                    "collections":["psul_catalog_v1"]}')
+        stub_request(:get, "#{config_obj.url}/solr/admin/collections?action=MODIFY")
+          .to_return(status: 200)
       end
 
       it 'does add a new collection' do


### PR DESCRIPTION
We could get ourselves in a pickle if we were testing a collection, and then restart the pod. (the pod would change the pointer to the last_incremented_collection)

Here, we only create the alias when the collection has been initialized, else we rely on someone, or something to run the create_alias task after verification of the new collection has been completed. 