### PR TITLE
Availability: Remove scan request locations

### DIFF
--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -15,6 +15,7 @@ const availability = {
     allLocations: locations.locations,
     allLibraries: locations.libraries,
     illiadLocations: locations.request_via_ill,
+    reservesScanLocations: locations.reserves_scan,
     allItemTypes: item_types.item_types,
     reserveCirculationRules: reserve_circulation_rules.reserve_circulation_rules,
     movedLocations: [],
@@ -523,7 +524,7 @@ const availability = {
     },
 
     isReserves(holding) {
-        return ['RESERVE-EM', 'RESERVE-EG', 'RESERVE-PM'].includes(holding.locationID);
+        return availability.reservesScanLocations.includes(holding.locationID);
     },
 
     isMicroform(holding) {

--- a/app/javascript/availability/libraries_locations.json
+++ b/app/javascript/availability/libraries_locations.json
@@ -773,5 +773,7 @@
     "REPAIR": "Copy unavailable, request via Interlibrary Loan",
     "CANCELED": "Copy unavailable, request via Interlibrary Loan",
     "CHECKEDOUT": "Checked out, request through Interlibrary Loan"
-  }
+  },
+  "reserves_scan": [
+  ]
 }


### PR DESCRIPTION
Closes #824.

Moves scan location array into `libraries_locations.json` and removes all locations from that array, effectively disabling the scan request functionality.

Adding locations back to the array will re-enable the feature for the locations in the array.