### PR TITLE
Update Gemfile with spring and launchy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,22 +34,27 @@ group :development do
   gem 'foreman', '~> 0.63.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
+  gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console'
 end
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'capybara'
   gem 'niftany', '~> 0.9'
   gem 'pry-byebug'
+  gem 'sinatra'
+  gem 'sqlite3'
+end
+
+group :test do
+  gem 'capybara'
+  gem 'launchy'
   gem 'rails-controller-testing'
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
   gem 'simplecov', '< 0.18', require: false # CodeClimate does not work with .18 or later
-  gem 'sinatra'
-  gem 'sqlite3'
   gem 'vcr'
   gem 'webdrivers', '~> 4.0'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     lcsort (0.9.1)
     library_stdnums (1.6.0)
     listen (3.1.5)
@@ -414,6 +416,8 @@ GEM
     slop (4.8.2)
     smart_properties (1.15.0)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -496,6 +500,7 @@ DEPENDENCIES
   faraday
   foreman (~> 0.63.0)
   high_voltage (~> 3.1)
+  launchy
   lcsort (~> 0.9)
   listen (>= 3.0.5, < 3.2)
   lograge
@@ -514,6 +519,7 @@ DEPENDENCIES
   simplecov (< 0.18)
   sinatra
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   vcr

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version


### PR DESCRIPTION
Tweak the Gemfile to segregate specific dependencies for our test environment. Adds the launchy gem to enable `save_and_open_page` from feature tests, and configures Spring with RSpec for faster test runs.