### PR TITLE
Use descendent_path for subject_browse_facet

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -11,6 +11,7 @@
     <field name="_version_" type="long" indexed="true" stored="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
     <field name="subject_facet" type="descendent_path" indexed="true" stored="true" multiValued="true"/>
+    <field name="subject_browse_facet" type="descendent_path" indexed="true" stored="true" multiValued="true"/>
 
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
@@ -225,7 +226,6 @@
     <field name="lc_1letter_facet"    type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
     <field name="lc_rest_facet"       type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
     <field name="subject_topic_facet" type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
-    <field name="subject_browse_facet" type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
     <field name="media_type_facet"    type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
     <field name="campus_facet"        type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
     <field name="up_library_facet"    type="string" docValues="true" indexed="true" stored="false" multiValued="true" />

--- a/spec/features/browse/subject_spec.rb
+++ b/spec/features/browse/subject_spec.rb
@@ -15,25 +15,25 @@ RSpec.feature 'Subject Browse', type: :feature do
       end
 
       within('tbody tr:nth-child(1)') do
-        expect(page).to have_link('Acetaldehyde—Germany')
+        expect(page).to have_link('Acetaldehyde')
         expect(page).to have_selector('td', text: 1)
       end
 
       within('tbody tr:nth-child(10)') do
-        expect(page).to have_link('African Americans—Southern States')
+        expect(page).to have_link('African American women lawyers')
         expect(page).to have_selector('td', text: 1)
       end
 
       first(:link, 'Next').click
 
       within('tbody tr:nth-child(1)') do
-        expect(page).to have_link('Aggada')
+        expect(page).to have_link('African American women lawyers—Illinois')
         expect(page).to have_selector('td', text: 1)
       end
 
       within('tbody tr:nth-child(10)') do
-        expect(page).to have_link('Analog-to-digital converters—Standards')
-        expect(page).to have_selector('td', text: 1)
+        expect(page).to have_link('Aggada')
+        expect(page).to have_selector('td', text: 2)
       end
     end
   end
@@ -50,25 +50,25 @@ RSpec.feature 'Subject Browse', type: :feature do
       end
 
       within('tbody tr:nth-child(1)') do
-        expect(page).to have_link('Analog-to-digital converters—Testing—Standards')
+        expect(page).to have_link('Aggada—Translations into Yiddish')
         expect(page).to have_selector('td', text: 1)
       end
 
       within('tbody tr:nth-child(10)') do
-        expect(page).to have_link('Australian literature—Periodicals')
+        expect(page).to have_link('American fiction—African American authors')
         expect(page).to have_selector('td', text: 1)
       end
 
       first(:link, 'Previous').click
 
       within('tbody tr:nth-child(1)') do
-        expect(page).to have_link('Aggada')
+        expect(page).to have_link('African American women lawyers—Illinois')
         expect(page).to have_selector('td', text: 1)
       end
 
       within('tbody tr:nth-child(10)') do
-        expect(page).to have_link('Analog-to-digital converters—Standards')
-        expect(page).to have_selector('td', text: 1)
+        expect(page).to have_link('Aggada')
+        expect(page).to have_selector('td', text: 2)
       end
     end
   end

--- a/spec/services/subject_list_spec.rb
+++ b/spec/services/subject_list_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe SubjectList do
     it { is_expected.not_to be_last_page }
 
     specify do
-      expect(list.entries.first.value).to eq('Acetaldehyde—Germany')
+      expect(list.entries.first.value).to eq('Acetaldehyde')
       expect(list.entries.first.hits).to eq(1)
-      expect(list.entries.last.value).to eq('African Americans—Southern States')
+      expect(list.entries.last.value).to eq('African American women lawyers')
       expect(list.entries.last.hits).to eq(1)
       expect(list.entries.count).to eq(10)
     end
@@ -27,10 +27,10 @@ RSpec.describe SubjectList do
     it { is_expected.not_to be_last_page }
 
     specify do
-      expect(list.entries.first.value).to eq('Aggada')
+      expect(list.entries.first.value).to eq('African American women lawyers—Illinois')
       expect(list.entries.first.hits).to eq(1)
-      expect(list.entries.last.value).to eq('Analog-to-digital converters—Standards')
-      expect(list.entries.last.hits).to eq(1)
+      expect(list.entries.last.value).to eq('Aggada')
+      expect(list.entries.last.hits).to eq(2)
       expect(list.entries.count).to eq(10)
     end
   end
@@ -41,27 +41,27 @@ RSpec.describe SubjectList do
     it { is_expected.not_to be_last_page }
 
     specify do
-      expect(list.entries[0].value).to eq('Acetaldehyde—Germany')
+      expect(list.entries[0].value).to eq('Acetaldehyde')
       expect(list.entries[0].hits).to eq(1)
-      expect(list.entries[9].value).to eq('African Americans—Southern States')
+      expect(list.entries[9].value).to eq('African American women lawyers')
       expect(list.entries[9].hits).to eq(1)
-      expect(list.entries[10].value).to eq('Aggada')
+      expect(list.entries[10].value).to eq('African American women lawyers—Illinois')
       expect(list.entries[10].hits).to eq(1)
-      expect(list.entries[19].value).to eq('Analog-to-digital converters—Standards')
-      expect(list.entries[19].hits).to eq(1)
+      expect(list.entries[19].value).to eq('Aggada')
+      expect(list.entries[19].hits).to eq(2)
       expect(list.entries.count).to eq(20)
     end
   end
 
   context 'when this is the last page' do
-    subject(:list) { described_class.new(page: 15, length: 50) }
+    subject(:list) { described_class.new(page: 26, length: 50) }
 
     it { is_expected.to be_last_page }
 
     specify do
-      expect(list.entries.first.value).to eq('Women in war—Juvenile fiction')
+      expect(list.entries.first.value).to eq('Women—Fiction')
       expect(list.entries.first.hits).to eq(1)
-      expect(list.entries.count).to eq(37)
+      expect(list.entries.count).to eq(50)
     end
   end
 
@@ -71,9 +71,9 @@ RSpec.describe SubjectList do
     it { is_expected.not_to be_last_page }
 
     specify do
-      expect(list.entries.first.value).to eq('Magic—Fiction')
+      expect(list.entries.first.value).to eq('Magic')
       expect(list.entries.first.hits).to eq(1)
-      expect(list.entries.last.value).to eq('Married people—Drama')
+      expect(list.entries.last.value).to eq('Man-woman relationships—Senegal—Dakar')
       expect(list.entries.last.hits).to eq(1)
       expect(list.entries.count).to eq(10)
     end


### PR DESCRIPTION
Uses the same field type as `subject_facet` so they're both indexed the same way.