### PR TITLE
Forms for subject browsing

### DIFF
--- a/app/components/browse/prefix_selector.html.erb
+++ b/app/components/browse/prefix_selector.html.erb
@@ -1,12 +1,31 @@
-<nav class="alpha-filter">
-  <ol class="pagination pagination-sm justify-content-center">
-    <li class="page-item <%= 'active' if prefix.blank? %>">
-      <%= link_to 'All', clear_prefix_path, class: 'page-link' %>
-    </li>
-    <% ('A'..'Z').to_a.each do |letter| %>
-      <li class="page-item <%= 'active' if prefix == letter %>">
-        <%= link_to letter, prefix_path(letter), class: 'page-link' %>
-      </li>
+<div class="row my-3">
+
+  <div class="col-9">
+    <nav class="alpha-filter">
+      <ol class="pagination pagination-sm mb-0">
+        <li class="page-item <%= 'active' if prefix.blank? %>">
+          <%= link_to t('.all'), clear_prefix_path, class: 'page-link' %>
+        </li>
+        <% ('A'..'Z').to_a.each do |letter| %>
+          <li class="page-item <%= 'active' if prefix == letter %>">
+            <%= link_to letter, prefix_path(letter), class: 'page-link' %>
+          </li>
+        <% end %>
+      </ol>
+    </nav>
+  </div>
+
+  <div class="col-3">
+    <%= form_tag form_url, method: :get, id: 'browse-form', role: 'browse' do %>
+      <label for="prefix" class="sr-only"><%= t('.label') %></label>
+      <div class="input-group">
+        <span class="input-group-prepend input-group-text"><%= t('.label') %></span>
+        <%= text_field_tag :prefix,
+                           prefix,
+                           class: 'form-control',
+                           id: 'prefix',
+                           size: 5 %>
+      </div>
     <% end %>
-  </ol>
-</nav>
+  </div>
+</div>

--- a/app/components/browse/prefix_selector.rb
+++ b/app/components/browse/prefix_selector.rb
@@ -14,6 +14,10 @@ module Browse
       browse_subjects_path(merge_params(prefix: letter))
     end
 
+    def form_url
+      browse_subjects_url
+    end
+
     private
 
       def merge_params(opts = {})

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BrowseController < ApplicationController
+  before_action :normalize_parameters
+
   def index
     @shelf_list = ShelfListPresenter.new(shelf_list_params)
   end
@@ -10,6 +12,10 @@ class BrowseController < ApplicationController
   end
 
   private
+
+    def normalize_parameters
+      params[:prefix].try(:capitalize!)
+    end
 
     def shelf_list_params
       params.permit(:starting, :ending, :length, :nearby)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -403,12 +403,18 @@ class CatalogController < ApplicationController
       field.solr_parameters = { qf: 'publisher_manufacturer_tsim' }
     end
 
-    config.add_search_field('browse_cn') do |field|
-      field.include_in_advanced_search = false
-      field.label = 'Browse by Call Number'
+    # @todo Temporarily restricts this to non-production hosts
+    unless Settings.matomo_id.to_i == 7
+      config.add_search_field('browse_cn') do |field|
+        field.include_in_advanced_search = false
+        field.label = 'Browse by Call Number'
+      end
     end
-    # config.add_search_field('Publisher')
-    # config.add_search_field('Publication date')
+
+    config.add_search_field('browse_subjects') do |field|
+      field.include_in_advanced_search = false
+      field.label = 'Browse by Subject'
+    end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,8 +5,11 @@ class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
-  include ::ReportIssue
+  include Browse
+  include ReportIssue
   include SearchContext
+
+  before_action :redirect_browse
 
   def index
     cache_key = nil
@@ -398,6 +401,11 @@ class CatalogController < ApplicationController
     config.add_search_field('publisher') do |field|
       field.include_in_simple_select = false
       field.solr_parameters = { qf: 'publisher_manufacturer_tsim' }
+    end
+
+    config.add_search_field('browse_cn') do |field|
+      field.include_in_advanced_search = false
+      field.label = 'Browse by Call Number'
     end
     # config.add_search_field('Publisher')
     # config.add_search_field('Publication date')

--- a/app/controllers/concerns/browse.rb
+++ b/app/controllers/concerns/browse.rb
@@ -4,8 +4,19 @@ module Browse
   extend ActiveSupport::Concern
 
   def redirect_browse
-    if params[:q] && params[:search_field] == 'browse_cn'
-      redirect_to "/browse/?nearby=#{CGI.escape params[:q]}"
+    return if params[:q].blank?
+
+    case params[:search_field]
+    when 'browse_cn'
+      redirect_to browse_path(nearby: search_params)
+    when 'browse_subjects'
+      redirect_to browse_subjects_path(prefix: search_params)
     end
   end
+
+  private
+
+    def search_params
+      CGI.escape(params[:q])
+    end
 end

--- a/app/controllers/concerns/browse.rb
+++ b/app/controllers/concerns/browse.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Browse
+  extend ActiveSupport::Concern
+
+  def redirect_browse
+    if params[:q] && params[:search_field] == 'browse_cn'
+      redirect_to "/browse/?nearby=#{CGI.escape params[:q]}"
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,35 +31,39 @@
 
 en:
   blackcat:
-      hathitrust:
-        mono_url: https://hdl.handle.net/2027/
-        multi_url: https://catalog.hathitrust.org/Record/
-        url_append: '?urlappend=%3B&signon=swle:urn:mace:incommon:psu.edu'
-        public_domain_text: 'Access digital copy through HathiTrust'
-        restricted_access_text: 'Search inside at HathiTrust'
-        etas_text: 'Check out digital copy through HathiTrust'
-        etas_additional_text: >
-          Digital access to this item through the HathiTrust Emergency Temporary Access Service will
-          conclude on July 9, 2021. Requests for most library materials will be possible through
-          "I Want It." On-shelf access will resume as libraries fully re-open over the summer. We will
-          retain digital access to public domain materials in HathiTrust.
-      facet_tooltips:
-        access_facet:
-          free_to_read: 'These materials don''t require a Penn State login'
-          online: 'These materials may require a Penn State login'
-      report_issue:
-        form:
-          title: 'Report an Issue'
-          record_title: 'Title'
-          record_number: 'Record Number'
-          comment: 'Comment (required)'
-          email: 'Email Address (optional, if you''d like a reply)'
-        email:
-          subject: 'Penn State University Libraries Catalog - Issue Report'
-          title: 'Title: %{title}'
-          record_number: 'Record Number: %{record_number}'
-          record_url: 'Record URL: https://catalog.libraries.psu.edu/catalog/%{record_number}'
-          comment: 'Comment:'
-          email: 'Email Address: %{email}'
-        errors:
-          comment: 'Please enter a comment'
+    hathitrust:
+      mono_url: https://hdl.handle.net/2027/
+      multi_url: https://catalog.hathitrust.org/Record/
+      url_append: '?urlappend=%3B&signon=swle:urn:mace:incommon:psu.edu'
+      public_domain_text: 'Access digital copy through HathiTrust'
+      restricted_access_text: 'Search inside at HathiTrust'
+      etas_text: 'Check out digital copy through HathiTrust'
+      etas_additional_text: >
+        Digital access to this item through the HathiTrust Emergency Temporary Access Service will
+        conclude on July 9, 2021. Requests for most library materials will be possible through
+        "I Want It." On-shelf access will resume as libraries fully re-open over the summer. We will
+        retain digital access to public domain materials in HathiTrust.
+    facet_tooltips:
+      access_facet:
+        free_to_read: 'These materials don''t require a Penn State login'
+        online: 'These materials may require a Penn State login'
+    report_issue:
+      form:
+        title: 'Report an Issue'
+        record_title: 'Title'
+        record_number: 'Record Number'
+        comment: 'Comment (required)'
+        email: 'Email Address (optional, if you''d like a reply)'
+      email:
+        subject: 'Penn State University Libraries Catalog - Issue Report'
+        title: 'Title: %{title}'
+        record_number: 'Record Number: %{record_number}'
+        record_url: 'Record URL: https://catalog.libraries.psu.edu/catalog/%{record_number}'
+        comment: 'Comment:'
+        email: 'Email Address: %{email}'
+      errors:
+        comment: 'Please enter a comment'
+  browse:
+    prefix_selector:
+      all: 'All'
+      label: 'Starts with:'

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -13,11 +13,22 @@ RSpec.describe 'Catalog', type: :request do
     end
   end
 
-  describe 'Browse Search Redirects' do
+  describe 'browse call number redirects' do
     it 'browse_cn redirects to browse UI' do
+      current = Settings.matomo_id
+      Settings.matomo_id = 7
       get '/?search_field=browse_cn&q=ABC'
 
-      expect(response).to redirect_to '/browse/?nearby=ABC'
+      expect(response).to redirect_to '/browse?nearby=ABC'
+      Settings.matomo_id = current
+    end
+  end
+
+  describe 'browse subjects redirect' do
+    it 'redirects to the subject browse path' do
+      get '/?search_field=browse_subjects&q=ABC'
+
+      expect(response).to redirect_to '/browse/subjects?prefix=ABC'
     end
   end
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -12,4 +12,12 @@ RSpec.describe 'Catalog', type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'Browse Search Redirects' do
+    it 'browse_cn redirects to browse UI' do
+      get '/?search_field=browse_cn&q=ABC'
+
+      expect(response).to redirect_to '/browse/?nearby=ABC'
+    end
+  end
 end


### PR DESCRIPTION
This adds a drop-down option for browsing subject from a specific prefix and capitalizes any entered values so they'll work correctly with our already-capitalized facets.

It resurrects a blocked commit for call number browse because we want to do the same thing with subjects. However, call number browse needs to be hidden from non-prod hosts, so the option is blocked if we're using the Matomo ID for production.

Using the same technique we use for call numbers, we add an option for subject browsing, which redirects to the subject browse form. The PrefixSelector component is updated to include an input for supplying a custom prefix other than the canned letters.