### PR TITLE
Updating our dev-related tasks

### DIFF
--- a/bin/create_fixtures
+++ b/bin/create_fixtures
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd ../psulib_traject
+bundle exec traject \
+  -c config/traject.rb \
+  -w Traject::JsonWriter \
+  -o ../psulib_blacklight/spec/fixtures/current_fixtures.json \
+  ../psulib_blacklight/solr/sample_data/*.mrc

--- a/lib/psulib_blacklight/data_manager.rb
+++ b/lib/psulib_blacklight/data_manager.rb
@@ -17,5 +17,14 @@ module PsulibBlacklight
       Blacklight.default_index.connection.add(docs)
       Blacklight.default_index.connection.commit
     end
+
+    # @note We'd usually use a gem like DatabaseCleaner to do this, but since our database usage is so small, this
+    # seems like a simpler approach. These are SQLite commands only.
+    def self.clean_database
+      ['users', 'bookmarks'].map do |table_name|
+        ActiveRecord::Base.connection.execute("DELETE FROM #{table_name}")
+      end
+      ActiveRecord::Base.connection.execute('VACUUM')
+    end
   end
 end

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -8,31 +8,37 @@ namespace :solr do
     @solr_manager ||= PsulibBlacklight::SolrManager.new
   end
 
+  desc 'Remove all data from Solr'
   task clean: :environment do
     PsulibBlacklight::DataManager.clean_solr
   end
 
+  desc 'Creates or updates the collection in solr'
   task initialize_collection: :environment do
     solr_manager.initialize_collection
   end
 
-  # create a new collection with a configset that is up to date.
+  desc 'Create a new collection with a configset that is up to date'
   task create_collection: :environment do
     solr_manager.create_collection
   end
 
+  desc 'Creates the alias to the latest collection in solr'
   task create_alias: :environment do
     solr_manager.create_alias
   end
 
+  desc 'Load the test fixtures'
   task load_fixtures: :environment do
     PsulibBlacklight::DataManager.load_fixtures
   end
 
+  desc 'Updates the configuration'
   task update_config: :environment do
     solr_manager.modify_collection
   end
 
+  desc 'Return the latest collection version number'
   task last_incremented_collection: :environment do
     puts solr_manager.last_incremented_collection
   end

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -4,14 +4,18 @@ require 'psulib_blacklight/data_manager'
 
 RSpec.configure do |config|
   config.before :suite do
+    PsulibBlacklight::DataManager.clean_database
     PsulibBlacklight::DataManager.clean_redis
     PsulibBlacklight::DataManager.clean_solr
     PsulibBlacklight::DataManager.load_fixtures
   end
 
+  config.after :suite do
+    PsulibBlacklight::DataManager.clean_database
+  end
+
   config.before do |example|
-    if example.metadata[:redis]
-      PsulibBlacklight::DataManager.clean_redis
-    end
+    ActionMailer::Base.deliveries.clear
+    PsulibBlacklight::DataManager.clean_redis if example.metadata[:redis]
   end
 end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
 namespace :dev do
-  namespace :traject do
-    desc 'Generate fixtures using Traject'
-    task create_fixtures: :environment do
-      # Note: updates to the sample_psucat.mrc file are produced by Maryam. We can request a new version of the file
-      # with examples that we are seeking and she will produce it and place it on the symphony server.
-      traject_path = Rails.root.join('../psulib_traject')
-      fixtures = Rails.root.join('spec/fixtures/current_fixtures.json')
-      marc_file = Rails.root.join('solr/sample_data/*.mrc')
-      args = "-c lib/traject/psulib_config.rb -w Traject::JsonWriter -o #{fixtures}"
-      version = 'RBENV_VERSION=jruby-9.2.11.1'
-      Bundler.with_clean_env do
-        system("cd #{traject_path} && /bin/bash -l -c '#{version} bundle exec traject #{args} #{marc_file}'")
-      end
-    end
+  desc 'Clean out everything and reload fixtures'
+  task clean: :environment do
+    PsulibBlacklight::DataManager.clean_redis
+    PsulibBlacklight::DataManager.clean_database
+    PsulibBlacklight::DataManager.clean_solr
+    PsulibBlacklight::SolrManager.new.initialize_collection
+    PsulibBlacklight::DataManager.load_fixtures
   end
 end


### PR DESCRIPTION
This add a new 'dev:clean' task which wipes out everything, loads any new solr configuration, and loads fixtures. It ensures that your dev environment is in a clean state and has the latest solr configuration.

Additionally, descriptions are added to the solr.rake tasks so that they'll list properly when running rake -T.

It's worth noting that we're not using the DatabaseCleaner gem to do the database truncation because it's not really worth it. Instead of introducing another dependency, we can truncate the tables via SQLite to remove the data, and rely on Rails' use_transactional_fixtures to take care the rest in between tests.