### PR TITLE
load fixtures switch

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -18,6 +18,11 @@ bundle exec rails db:migrate
 echo "initalizing solr"
 bundle exec rake solr:initialize_collection
 
+if [ "${LOAD_FIXTURES:-false}" == "true" ]; then
+  echo "Loading Fixtures"
+  bundle exec rake solr:load_fixtures
+fi
+
 echo "starting rails"
 
 bundle exec rails s -b '0.0.0.0'


### PR DESCRIPTION
If a deployment has the `LOAD_FIXTURES` variable set, it will run the rake task to load the fixtures. 

This change is in conjunction with a default being set on preview envs 
https://github.com/psu-libraries/catalog-config/blob/main/templates/application.yaml#L23

your specific deployment can switch this on/off as you see fit. 