### PR TITLE
Add options for including lower term

### DIFF
--- a/app/services/shelf_list.rb
+++ b/app/services/shelf_list.rb
@@ -41,7 +41,8 @@ class ShelfList
       @forward_keys ||= TermsQuery.call(
         field: forward_shelfkey,
         limit: forward_limit,
-        query: query
+        query: query,
+        include_lower: 'false'
       )
     end
 

--- a/app/services/terms_query.rb
+++ b/app/services/terms_query.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 class TermsQuery
-  def self.call(field:, limit:, query:)
-    new(field, limit, query).terms
+  def self.call(field:, limit:, query:, include_lower: 'true')
+    new(field, limit, query, include_lower).terms
   end
 
   attr_reader :field, :limit, :query
 
-  def initialize(field, limit, query)
+  def initialize(field, limit, query, include_lower)
     @field = field
     @limit = limit
     @query = query
+    @include_lower = include_lower
   end
 
   # @return [Array<String>]
@@ -30,7 +31,7 @@ class TermsQuery
       .get('terms',
            params: {
              'terms' => true,
-             'terms.lower.incl' => true,
+             'terms.lower.incl' => include_lower?,
              'terms.fl' => field,
              'terms.lower' => query,
              'terms.limit' => limit,
@@ -38,4 +39,10 @@ class TermsQuery
            })
       .dig('terms', field) || []
   end
+
+  private
+
+    def include_lower?
+      @include_lower != 'false'
+    end
 end

--- a/spec/services/shelf_list_spec.rb
+++ b/spec/services/shelf_list_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe ShelfList do
         )
       end
 
-      it 'returns the book and the next four books that appear after it' do
+      it 'returns the next five books that appear after it, but not the book itself' do
         expect(list[:after].map(&:call_number)).to contain_exactly(
-          'G5761.F7 1963.G7',
           'G7273.T5 1968.S6',
           'G8961.C5 1931.D3',
           'GN320.G66 1993',
-          'GV979.S9B43 2005 DVD'
+          'GV979.S9B43 2005 DVD',
+          'GV1643.M36 no.2 1531'
         )
       end
 
-      it 'returns the book and the previous four books that appear before it in reverse order' do
+      it 'returns the book itself and the previous four books that appear before it in reverse order' do
         expect(list[:before].map(&:call_number)).to contain_exactly(
           'G125.M7665 1885',
           'G3803.W3J3 1956.N4',


### PR DESCRIPTION
When retrieving shelf lists with TermsQuery, we only need to include the lower term, which is the query term or book we're looking for, in either the forward or reverse set, but not _both_. Including it in both results in the book present in the forward and reverse set. When the shelf is then assembled with both queries, the book will appear twice.

Adding an option to include the lower term allows us to only request it for the reverse set and not the forward set. This creates a virtual shelf with the queried item only appearing once instead of twice.

Fixes #831 