### PR TITLE
Further normalization of browse prefix

### DIFF
--- a/app/services/browse_list.rb
+++ b/app/services/browse_list.rb
@@ -60,7 +60,9 @@ class BrowseList
       return if prefix.blank?
 
       normalized_prefix = prefix.dup
-      normalized_prefix[0] = normalized_prefix[0].upcase
-      normalized_prefix
+
+      normalized_prefix[0] = normalized_prefix[0].upcase # uppercase the first character
+      normalized_prefix.gsub!(/--/, '—') # replace 2 normal dashes with em dash
+      normalized_prefix.chomp('*') # remove trailing * (wildcard chars)
     end
 end

--- a/spec/services/browse_list_spec.rb
+++ b/spec/services/browse_list_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe BrowseList do
           field: 'browsing_facet',
           page: 2,
           length: 20,
-          prefix: 'tE'
+          prefix: 'tE--rM--*'
         ).entries
 
         expect(mock_connection).to have_received(:get).with(
@@ -74,7 +74,7 @@ RSpec.describe BrowseList do
               'facet.field' => 'browsing_facet',
               'facet.limit' => 21,
               'facet.offset' => 20,
-              'facet.prefix' => 'TE',
+              'facet.prefix' => 'TE—rM—',
               'facet.sort' => 'index',
               'rows' => '0'
             }


### PR DESCRIPTION
Closes #861.

To improve UX of the "starts with" browse form, we do a few more normalization steps:

- replace 2 regular dashes with an em dash
- remove trailing * chars (may be erroneously used as wildcards)