### PR TITLE
Remove CGI.escape() from redirect_browse

### DIFF
--- a/app/controllers/concerns/browse.rb
+++ b/app/controllers/concerns/browse.rb
@@ -8,17 +8,13 @@ module Browse
 
     case params[:search_field]
     when 'browse_cn'
-      redirect_to browse_path(nearby: search_params)
+      redirect_to browse_path(nearby: params[:q])
     when 'browse_authors'
-      redirect_to browse_authors_path(prefix: search_params)
+      redirect_to browse_authors_path(prefix: params[:q])
     when 'browse_subjects'
-      redirect_to browse_subjects_path(prefix: search_params)
+      redirect_to browse_subjects_path(prefix: params[:q])
+    when 'browse_titles'
+      redirect_to browse_titles_path(prefix: params[:q])
     end
   end
-
-  private
-
-    def search_params
-      CGI.escape(params[:q])
-    end
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -26,17 +26,17 @@ RSpec.describe 'Catalog', type: :request do
 
   describe 'browse authors redirect' do
     it 'redirects to the author browse path' do
-      get '/?search_field=browse_authors&q=ABC'
+      get '/?search_field=browse_authors&q=Abbott, Deborah'
 
-      expect(response).to redirect_to '/browse/authors?prefix=ABC'
+      expect(response).to redirect_to '/browse/authors?prefix=Abbott%2C+Deborah'
     end
   end
 
   describe 'browse subjects redirect' do
     it 'redirects to the subject browse path' do
-      get '/?search_field=browse_subjects&q=ABC'
+      get '/?search_field=browse_subjects&q=African Americans--'
 
-      expect(response).to redirect_to '/browse/subjects?prefix=ABC'
+      expect(response).to redirect_to '/browse/subjects?prefix=African+Americans--'
     end
   end
 end


### PR DESCRIPTION
Fixes #885.

The search query was already being escaped properly, and adding `CGI.escape()` on top of that was actually causing errors.