### PR TITLE
Use shelvit gem to convert user call number input into shelf keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'rails', '~> 6.0.4'
 gem 'redis', '~> 4.2'
 gem 'rsolr', '>= 1.0'
 gem 'rubyzip'
+gem 'shelvit'
 gem 'stackprof'
 gem 'webpacker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    shelvit (0.1.1)
+      lcsort (~> 0.9)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
     simplecov (0.17.1)
@@ -519,6 +521,7 @@ DEPENDENCIES
   rspec-rails
   rubyzip
   selenium-webdriver
+  shelvit
   shoulda-matchers
   simplecov (< 0.18)
   sinatra

--- a/app/presenters/shelf_list_presenter.rb
+++ b/app/presenters/shelf_list_presenter.rb
@@ -56,6 +56,10 @@ class ShelfListPresenter
       (before_items + after_items)
     end
 
+    def shelf_key
+      @shelf_key ||= Shelvit.normalize(nearby) || nearby
+    end
+
     # @return [Array<ShelfItem>]
     # @note The items coming before a particular call number are determined using a reverse shelf key, which means the
     # items are returned in a "reverse" order. To create a natural reading list, we need to reverse the reversed list
@@ -65,9 +69,9 @@ class ShelfListPresenter
     def before_items
       before_list = shelf_list[:before].reverse
 
-      return before_list if nearby.blank?
+      return before_list if shelf_key.blank?
 
-      if before_list.last.call_number == nearby
+      if before_list.last.key == shelf_key
         before_list.last.match = true
       else
         before_list << ShelfItem.new(label: "You're looking for: #{nearby}", call_number: 'None', key: nil)
@@ -106,8 +110,8 @@ class ShelfListPresenter
         { query: starting, forward_limit: length, reverse_limit: 2 }
       elsif ending.present?
         { query: ending, forward_limit: 1, reverse_limit: length + 1 }
-      elsif nearby.present?
-        { query: nearby, forward_limit: (length - MIN) + 2, reverse_limit: MIN }
+      elsif shelf_key.present?
+        { query: shelf_key, forward_limit: (length - MIN) + 2, reverse_limit: MIN }
       else
         { query: '0', forward_limit: length + 1, reverse_limit: 0 }
       end

--- a/app/views/browse/_call_numbers.html.erb
+++ b/app/views/browse/_call_numbers.html.erb
@@ -17,7 +17,7 @@
     <% shelf_list.list.map do |shelf_item| %>
       <% if shelf_item.nearby? && !shelf_item.match? %>
         <tr class="table-primary">
-          <td colspan="4"><%= shelf_item.call_number %></td>
+          <td colspan="4"><%= shelf_item.label %></td>
         </tr>
       <% else %>
         <% shelf_item.documents.map do |doc| %>

--- a/spec/features/browse/call_number_spec.rb
+++ b/spec/features/browse/call_number_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Call Number Browse', type: :feature do
         visit '/browse/call_numbers?nearby=F592.4 1983'
 
         expect(page).to have_selector 'h2.h4',
-                                      exact_text: 'F158.9.J5P3 1959 to GN320.G66 1993'
+                                      exact_text: 'F158.9.J5P3 1959 to G8961.C5 1931.D3'
 
         expect(page).to have_link('F592.4 1983', href: '/catalog/492891')
 
@@ -52,7 +52,7 @@ RSpec.feature 'Call Number Browse', type: :feature do
                                       exact_text: 'LC1421.M83 1801 v.1-2 to M450.Y56A6 2013 CD'
 
         expect(page).to have_selector 'tr.table-primary:nth-child(2) td',
-                                      exact_text: 'None'
+                                      exact_text: 'You\'re looking for: LOL'
       end
     end
   end


### PR DESCRIPTION
Closes #888.

This should improve the browse experience since we are now querying on normalized shelf keys instead of the base call numbers.