### PR TITLE
Add custom placeholder text for browse queries in search bar

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -442,16 +442,19 @@ class CatalogController < ApplicationController
       config.add_search_field('browse_cn') do |field|
         field.include_in_advanced_search = false
         field.label = 'Browse by Call Number'
+        field.placeholder_text = 'e.g. NK 9112 .A28'
       end
 
       config.add_search_field('browse_authors') do |field|
         field.include_in_advanced_search = false
         field.label = 'Browse by Author'
+        field.placeholder_text = 'e.g. Hurston, Zora'
       end
 
       config.add_search_field('browse_subjects') do |field|
         field.include_in_advanced_search = false
         field.label = 'Browse by Subject'
+        field.placeholder_text = 'e.g. Microbiology'
       end
 
       config.add_search_field('browse_titles') do |field|

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -129,4 +129,41 @@ module CatalogHelper
   def get_first_only(options = {})
     options[:value].first
   end
+
+  # Returns suitable argument to options_for_select method, to create
+  # an html select based on #search_field_list with labels for search
+  # bar only. Skips search_fields marked :include_in_simple_select => false
+  def search_bar_select
+    blacklight_config.search_fields.map do |_key, field_def|
+      if should_render_field?(field_def)
+        [
+          field_def.dropdown_label ||
+            field_def.label, field_def.key, { 'data-placeholder' => placeholder_text(field_def) }
+        ]
+      end
+    end.compact
+  end
+
+  def placeholder_text(field_def)
+    if field_def.respond_to?(:placeholder_text)
+      field_def.placeholder_text
+    else
+      t('blacklight.search.form.search.placeholder')
+    end
+  end
+
+  def search_bar_field
+    case params[:action]
+    when 'call_numbers'
+      'browse_cn'
+    when 'authors'
+      'browse_authors'
+    when 'subjects'
+      'browse_subjects'
+    when 'titles'
+      'browse_titles'
+    else
+      params[:search_field]
+    end
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,8 +7,9 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-import bookCovers from "../book_covers";
 import availability from "../availability";
+import bookCovers from "../book_covers";
+import search from "../search";
 
 require.context('../psulib_blacklight/images/', true);
 
@@ -26,6 +27,7 @@ import 'blacklight_overrides'
 document.addEventListener("turbolinks:load", function() {
     availability.executeAvailability();
     bookCovers.start();
+    search.autoPlaceholder();
     Blacklight.doBookmarkToggleBehavior();
     Blacklight.doSearchContextBehavior();
 });

--- a/app/javascript/search/index.js
+++ b/app/javascript/search/index.js
@@ -1,0 +1,30 @@
+const search = {
+    /**
+     * Updates the placeholder text in the main search form on initial page load
+     * and whenever the search type dropdown changes
+     */
+    autoPlaceholder: () => {
+        const searchType = document.getElementById('search_field');
+
+        const updatePlaceholder = () => {
+            if (!searchType || !searchType.options) {
+                return;
+            }
+
+            const placeholder = searchType.options[searchType.selectedIndex].dataset['placeholder'];
+            const q = document.getElementById('q');
+
+            q.setAttribute('placeholder', placeholder);
+        };
+
+        $(() => {
+            updatePlaceholder();
+        });
+
+        searchType.addEventListener('change', () => {
+            updatePlaceholder();
+        });
+    },
+};
+
+export default search;

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -7,7 +7,7 @@
     <div class="input-group">
       <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
-                       options_for_select(search_fields, h(params[:search_field])),
+                       options_for_select(search_bar_select, search_bar_field),
                        title: t('blacklight.search.form.search_field.title'),
                        id: 'search_field',
                        class: 'custom-select search-field') %>

--- a/spec/features/search_bar_spec.rb
+++ b/spec/features/search_bar_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Search Bar', type: :feature do
+  describe 'selected search box field', js: true do
+    it 'shows normal placeholder info when doing a keyword search' do
+      visit '/?search_field=all_fields&q='
+      expect(page).to have_select('search_field', selected: 'Keyword')
+      expect(page).to have_selector('#q[placeholder="Search..."]')
+    end
+
+    it 'shows call number browse info when browsing by call number' do
+      visit '/browse/call_numbers?nearby=LOL'
+      expect(page).to have_select('search_field', selected: 'Browse by Call Number')
+      expect(page).to have_selector('#q[placeholder="e.g. NK 9112 .A28"]')
+    end
+
+    it 'shows author browse info when browsing by author' do
+      visit '/browse/authors?prefix=A'
+      expect(page).to have_select('search_field', selected: 'Browse by Author')
+      expect(page).to have_selector('#q[placeholder="e.g. Hurston, Zora"]')
+    end
+
+    it 'shows subject browse info when browsing by subject' do
+      visit '/browse/subjects?prefix=S'
+      expect(page).to have_select('search_field', selected: 'Browse by Subject')
+      expect(page).to have_selector('#q[placeholder="e.g. Microbiology"]')
+    end
+
+    it 'shows title browse info when browsing by title' do
+      visit '/browse/titles?prefix=T'
+      expect(page).to have_select('search_field', selected: 'Browse by Title')
+      expect(page).to have_selector('#q[placeholder="Search..."]')
+    end
+  end
+
+  it 'updates the placeholder when the search type changes', js: true do
+    visit '/'
+
+    expect(page).to have_selector('#q[placeholder="Search..."]')
+
+    select 'Browse by Call Number', from: 'search_field'
+    expect(page).to have_select('search_field', selected: 'Browse by Call Number')
+    expect(page).to have_selector('#q[placeholder="e.g. NK 9112 .A28"]')
+
+    select 'Browse by Author', from: 'search_field'
+    expect(page).to have_select('search_field', selected: 'Browse by Author')
+    expect(page).to have_selector('#q[placeholder="e.g. Hurston, Zora"]')
+
+    select 'Browse by Subject', from: 'search_field'
+    expect(page).to have_select('search_field', selected: 'Browse by Subject')
+    expect(page).to have_selector('#q[placeholder="e.g. Microbiology"]')
+
+    select 'Browse by Title', from: 'search_field'
+    expect(page).to have_select('search_field', selected: 'Browse by Title')
+    expect(page).to have_selector('#q[placeholder="Search..."]')
+  end
+end


### PR DESCRIPTION
Partially addresses #898.

Preview: http://catalog-browse-placeholder.dev.k8s.libraries.psu.edu/

<img width="752" alt="Screen Shot 2021-09-30 at 2 53 22 PM" src="https://user-images.githubusercontent.com/639920/135514080-3a6b28e5-c9db-4529-a181-ef0a49eb1278.png">

When the user selects one of the browse actions, we now update the placeholder text to show a helpful hint for that browse type.

We also remember their search/browse type selection if they select one of the browse options (i.e. we will remember if they selected Browse by Call Number and not reset the search type dropdown).