### PR TITLE
More specific error text for no results on author/subject browse

### DIFF
--- a/app/views/browse/_empty_authors.html.erb
+++ b/app/views/browse/_empty_authors.html.erb
@@ -1,0 +1,26 @@
+<div class="alert alert-warning my-3">
+  <h4>No authors found. Try the following tips to revise your search:</h4>
+
+  <ol>
+    <li>
+      Use the inverted form of the name.
+      <br>
+      <strong>Example:</strong> use "Le Guin, Urusula", not "Ursula Le Guin".
+    </li>
+    <li>
+      Be sure you're capitalizing the last name and first name (as appropriate).
+      <br>
+      <strong>Example:</strong> "Lin, Wei", not "lin, wei".
+    </li>
+    <li>
+      Shorten your search term. Try just the last name or the last name and first initial.
+      <br>
+      <strong>Example:</strong> instead of "Tchaikovsky, Piotr" try "Tchaikovsky" or "Tchaikovsky, P".
+    </li>
+    <li>
+      Check the spelling or try alternate spellings for names from languages that use non-Latin alphabets.
+      <br>
+      <strong>Example:</strong> instead of "Tchaikovsky, Piotr" try "Tchaikovsky, Peter" or "Tchaikovsky, P".
+    </li>
+  </ol>
+</div>

--- a/app/views/browse/_empty_subjects.html.erb
+++ b/app/views/browse/_empty_subjects.html.erb
@@ -1,0 +1,16 @@
+<div class="alert alert-warning my-3">
+  <h4>No subjects found. Try the following tips to revise your search:</h4>
+
+  <ol>
+    <li>
+      Shorten your search term.
+      <br>
+      <strong>Example:</strong> instead of "Bookbinding" try "Bookb" or "Bookbind" to get subjects for Bookbinders and Bookbinding. Or use "Immigr" to find subjects about Immigration, Immigrants, etc.
+    </li>
+    <li>
+      Try a related term, especially the technical form.
+      <br>
+      <strong>Example:</strong> instead of "Heart attack" try "Myocardial infarction".
+    </li>
+  </ol>
+</div>

--- a/app/views/browse/authors.html.erb
+++ b/app/views/browse/authors.html.erb
@@ -3,7 +3,7 @@
 <%= render Browse::PrefixSelector.new(prefix: @author_list.prefix) %>
 
 <% if @author_list.empty? %>
-  <%= render 'empty' %>
+  <%= render 'empty_authors' %>
 <% else %>
   <%= render 'authors', author_list: @author_list %>
 <% end %>

--- a/app/views/browse/subjects.html.erb
+++ b/app/views/browse/subjects.html.erb
@@ -3,7 +3,7 @@
 <%= render Browse::PrefixSelector.new(prefix: @subject_list.prefix) %>
 
 <% if @subject_list.empty? %>
-  <%= render 'empty' %>
+  <%= render 'empty_subjects' %>
 <% else %>
   <%= render 'subjects', subject_list: @subject_list %>
 <% end %>

--- a/spec/views/browse/authors.html.erb_spec.rb
+++ b/spec/views/browse/authors.html.erb_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'browse/authors', type: :view do
 
   it 'renders an error message when there are no items to show' do
     expect(rendered).not_to have_selector 'table'
-    expect(rendered).to have_selector '.alert-warning h2', text: 'No records found.'
+    expect(rendered).to have_selector '.alert-warning h4',
+                                      text: 'No authors found. Try the following tips to revise your search:'
+    expect(rendered).to have_selector 'ol'
   end
 end

--- a/spec/views/browse/subjects.html.erb_spec.rb
+++ b/spec/views/browse/subjects.html.erb_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'browse/subjects', type: :view do
 
   it 'renders an error message when there are no items to show' do
     expect(rendered).not_to have_selector 'table'
-    expect(rendered).to have_selector '.alert-warning h2', text: 'No records found.'
+    expect(rendered).to have_selector '.alert-warning h4',
+                                      text: 'No subjects found. Try the following tips to revise your search:'
+    expect(rendered).to have_selector 'ol'
   end
 end


### PR DESCRIPTION
Closes #898.

If a user browses by author or subject and gets no results, we now display some helpful hints that can help them refine their search.

### Author
<img width="1166" alt="Screen Shot 2021-11-29 at 11 16 15 AM" src="https://user-images.githubusercontent.com/639920/143903620-aa87bcfb-d2a3-4e24-b9a3-533c3718a737.png">

### Subject
<img width="1147" alt="Screen Shot 2021-11-29 at 11 16 20 AM" src="https://user-images.githubusercontent.com/639920/143903658-8acf94e1-22e1-45a8-a695-af9bd7815bb4.png">