### PR TITLE
solr:delete_collection rake task

### DIFF
--- a/lib/psulib_blacklight/solr_manager.rb
+++ b/lib/psulib_blacklight/solr_manager.rb
@@ -67,6 +67,20 @@ module PsulibBlacklight
       end
     end
 
+    def delete_collection(collection_name)
+      unless collections.include?(collection_name)
+        puts 'Collection Not found in solr. The following Collections are in solr:'
+        puts collections
+        return
+      end
+
+      resp = connection.post(PsulibBlacklight::SolrConfig::COLLECTION_PATH) do |req|
+        req.params = { "action": 'DELETE', "name": collection_name }
+      end
+
+      check_resp(resp)
+    end
+
     private
 
       def version_number(colection_name)

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -42,4 +42,11 @@ namespace :solr do
   task last_incremented_collection: :environment do
     puts solr_manager.last_incremented_collection
   end
+
+  desc 'Delete a collection from solr'
+  task :delete_collection, [:collection] => [:environment] do |_task, args|
+    raise 'Collection parameter required' unless args['collection']
+
+    solr_manager.delete_collection(args['collection'])
+  end
 end

--- a/spec/lib/psulib_blacklight/solr_manager_spec.rb
+++ b/spec/lib/psulib_blacklight/solr_manager_spec.rb
@@ -117,6 +117,37 @@ RSpec.describe PsulibBlacklight::SolrManager do
     end
   end
 
+  describe '#delete_collection' do
+    context 'when there is a collection to delete' do
+      before do
+        stub_request(:get, "#{config_obj.url}/solr/admin/collections?action=LIST")
+          .to_return(status: 200,
+                     body: '{"responseHeader":{"status":0, "QTime":11}, "collections":["psulib_blacklight_v2"]}',
+                     headers: {}).then
+        stub_request(:post, "#{config_obj.url}/solr/admin/collections?action=DELETE").with(
+          query: { "name": 'psulib_blacklight_v2' }
+        )
+      end
+
+      it 'deletes the collection' do
+        expect(solr_manager.delete_collection('psulib_blacklight_v2')).to equal 200
+      end
+    end
+
+    context 'when there is no collection to delete' do
+      before do
+        stub_request(:get, "#{config_obj.url}/solr/admin/collections?action=LIST")
+          .to_return(status: 200,
+                     body: '{"responseHeader":{"status":0, "QTime":11}, "collections":["psulib_blacklight_v2"]}',
+                     headers: {}).then
+      end
+
+      it 'does not delete any collection' do
+        expect(solr_manager.delete_collection('foo')).to eq nil
+      end
+    end
+  end
+
   describe '#modify_collection' do
     it 'updates the current collection\'s config set to the latest' do
       expect(solr_manager.modify_collection).to equal 200


### PR DESCRIPTION
Presently as part of our workflow, we will delete the collection in the solr admin, or by firing off a `curl` call 

delete_collection will delete the passed collection out of solr. if the collection isn't found, all collections that are in solr are emitted to screen so we can easily copy and paste. 

If we attempt to delete a collection that has an alias, solr will return an error. 

