### PR TITLE
Adds stemming to 'text' fieldType

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -19,6 +19,9 @@
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true"
            termPositions="true" termOffsets="true"/>
 
+    <field name="all_text_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true"
+           termPositions="true" termOffsets="true"/>
+
 
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
@@ -243,6 +246,11 @@
       destination field is to use the dynamic field syntax.
       copyField also supports a maxChars to copy setting.  -->
 
+  <copyField source="*_tsim" dest="all_text_teimv" maxChars="3000"/>
+  <copyField source="*_tesim" dest="all_text_teimv" maxChars="3000"/>
+  <copyField source="*_ssim" dest="all_text_teimv" maxChars="3000"/>
+  <copyField source="*_si" dest="all_text_teimv" maxChars="3000"/>
+
   <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_ssim" dest="all_text_timv" maxChars="3000"/>
@@ -322,7 +330,6 @@
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.TrimFilterFactory"/>
-        <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -322,6 +322,7 @@
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -125,6 +125,7 @@
          toc_ssim^200
          notes_summary_ssim
          all_text_timv
+         all_text_teimv
        </str>
        <str name="pf">
          title_unstem_search^1000000
@@ -150,6 +151,7 @@
          toc_ssim^200
          notes_summary_ssim^50
          all_text_timv^10
+         all_text_teimv^10
        </str>
        <str name="author_qf">
          author_unstem_search^200


### PR DESCRIPTION
There appears to be more than one way to handle this.  I'm not sure which is the best way.

~~I added stemming to the 'text' fieldType, which will impact a lot of the search fields.  Any field defined in the solr schema.xml that has `type="text"` will now use stemming.  I'm not sure if that'll be a problem.  I can scope it down if we think that would be better.~~

Updated this to add another full english text search using stemmer on top of the other full text search that doesn't use stemmer.  Doing this instead of adding the stemmer to all the 'text' fields that I mentioned in the strikethrough above ☝️ .

closes #954 