### PR TITLE
Add luggage cart icon for records categorized as Equipment

### DIFF
--- a/app/javascript/psulib_blacklight/styles/_psulib_icons.scss
+++ b/app/javascript/psulib_blacklight/styles/_psulib_icons.scss
@@ -50,6 +50,11 @@
   content: fa-content($fa-var-book-open);
 }
 
+.blacklight-equipment .blacklight-format::before,
+.faspsu-equipment::before {
+  content: fa-content($fa-var-luggage-cart);
+}
+
 .blacklight-games-toys .blacklight-format::before,
 .faspsu-games-toys::before {
   content: fa-content($fa-var-chess);


### PR DESCRIPTION
Closes #944.

<img width="1165" alt="Screen Shot 2022-03-23 at 10 57 30 AM" src="https://user-images.githubusercontent.com/639920/159760275-3352a034-10db-429a-9a34-0c9b0a875776.png">

<img width="759" alt="Screen Shot 2022-03-23 at 10 57 21 AM" src="https://user-images.githubusercontent.com/639920/159760301-dccfcf6b-9972-49b9-84d0-edafe0012e63.png">

