### PR TITLE
Remove the limit on thesis_dept_facet for advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,6 +88,7 @@ class CatalogController < ApplicationController
       'facet.limit' => -1,
       'f.language_facet.facet.limit' => -1,
       'f.format.facet.limit' => -1,
+      'f.thesis_dept_facet.facet.limit' => -1,
       'facet.sort' => 'index'
     }
     config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'


### PR DESCRIPTION
Without this change, only the first 11 (not sure why it's 11 and not 10... 🤔) alphabetical thesis departments were showing in the advanced search dropdown.

On my local, I tested this by indexing 12 different records each with different thesis departments.

### Before
<img width="525" alt="Screen Shot 2022-03-31 at 10 22 43 AM" src="https://user-images.githubusercontent.com/639920/161078053-6336ec0f-cd68-4a42-9f53-ac12e4fc7aa8.png">

### After
<img width="525" alt="Screen Shot 2022-03-31 at 10 22 56 AM" src="https://user-images.githubusercontent.com/639920/161078099-d040a3e3-6cba-43a0-a0c1-9113effced44.png">
