### PR TITLE
Availability: Update View More to show more items in pages of 100

### DIFF
--- a/app/javascript/availability/components/a11y_nav_button.jsx
+++ b/app/javascript/availability/components/a11y_nav_button.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+
+const A11yNavButton = ({ index, label, uniqueID }) => {
+  /**
+   * Changes focus to the desired `A11yRow` specified by the generated element ID.
+   *
+   * Allows screen reader users to page through the results in the holdings table.
+   */
+  const updateA11yFocus = () => {
+    const el = document.getElementById(`a11y-${uniqueID}-${index}`);
+    el.focus();
+  };
+
+  if (index === null) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        updateA11yFocus();
+      }}
+    >
+      {label}
+    </button>
+  );
+};
+
+// eslint-react: defines valid prop types passed to this component
+A11yNavButton.propTypes = {
+  index: PropTypes.number,
+  label: PropTypes.string,
+  uniqueID: PropTypes.string,
+};
+
+export default A11yNavButton;

--- a/app/javascript/availability/components/a11y_row.jsx
+++ b/app/javascript/availability/components/a11y_row.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import A11yNavButton from './a11y_nav_button';
 
 /**
  * Provides screen reader users of the Availability feature the ability to navigate through
@@ -61,17 +62,6 @@ const A11yRow = ({
     }
   };
 
-  /**
-   * Changes focus to the `A11yRow` specified by the index parameter.
-   * Allows screen reader users to page through the results in the holdings table.
-   * Called when a Previous/Next button is clicked.
-   * @param idx - The index of the `A11yRow` component to be focused.
-   */
-  const updateA11yFocus = (idx) => {
-    const el = document.getElementById(`a11y-${uniqueID}-${idx}`);
-    el.focus();
-  };
-
   return (
     <tr className="sr-only">
       <td
@@ -83,27 +73,17 @@ const A11yRow = ({
       >
         {holdingsPageHeading(holdingIndex)}
 
-        {prevA11yIndex(holdingIndex) !== null && (
-          <button
-            type="button"
-            onClick={() => {
-              updateA11yFocus(prevA11yIndex(holdingIndex));
-            }}
-          >
-            Previous
-          </button>
-        )}
+        <A11yNavButton
+          index={prevA11yIndex(holdingIndex)}
+          label="Previous"
+          uniqueID={uniqueID}
+        />
 
-        {nextA11yIndex(holdingIndex) !== null && (
-          <button
-            type="button"
-            onClick={() => {
-              updateA11yFocus(nextA11yIndex(holdingIndex));
-            }}
-          >
-            Next
-          </button>
-        )}
+        <A11yNavButton
+          index={nextA11yIndex(holdingIndex)}
+          label="Next"
+          uniqueID={uniqueID}
+        />
       </td>
     </tr>
   );

--- a/app/javascript/availability/components/a11y_row.jsx
+++ b/app/javascript/availability/components/a11y_row.jsx
@@ -1,0 +1,122 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Provides screen reader users of the Availability feature the ability to navigate through
+ * the holdings table using the previous/next buttons. Clicking the buttons sets the focus
+ * to the previous/next page of elements, respectively.
+ */
+const A11yRow = ({
+  lastA11yIndex,
+  holdingIndex,
+  initialVisibleCount,
+  pageSize,
+  uniqueID,
+  visibleHoldingsCount,
+}) => {
+  const holdingsPageHeading = (idx) => {
+    let lastIndex = initialVisibleCount;
+
+    if (idx > 0) {
+      lastIndex = 1 + Math.min(idx + pageSize, visibleHoldingsCount - 1);
+    }
+
+    return `Holdings ${idx + 1} - ${lastIndex}`;
+  };
+
+  const prevA11yIndex = (idx) => {
+    if (idx === 0) {
+      return null;
+    }
+
+    if (idx === initialVisibleCount) {
+      return 0;
+    }
+
+    return idx - pageSize;
+  };
+
+  const nextA11yIndex = (idx) => {
+    if (idx === 0 && visibleHoldingsCount > initialVisibleCount) {
+      return initialVisibleCount;
+    }
+
+    if (idx + pageSize >= visibleHoldingsCount) {
+      return null;
+    }
+
+    return idx + pageSize;
+  };
+
+  /**
+   * If this newly-created `A11yRow` is the last `A11yRow` in the containing table,
+   * focus it so that screen reader users are aware that new elements have been
+   * added to the table.
+   * Called on initial render of this component.
+   * @param el - The `<td>` element considered for focus.
+   * @param idx - The current index of the `A11yRow` component inside the holdings table.
+   */
+  const focusNewA11yRow = (el, idx) => {
+    if (el && lastA11yIndex > 0 && idx === lastA11yIndex) {
+      el.focus();
+    }
+  };
+
+  /**
+   * Changes focus to the `A11yRow` specified by the index parameter.
+   * Allows screen reader users to page through the results in the holdings table.
+   * Called when a Previous/Next button is clicked.
+   * @param idx - The index of the `A11yRow` component to be focused.
+   */
+  const updateA11yFocus = (idx) => {
+    const el = document.getElementById(`a11y-${uniqueID}-${idx}`);
+    el.focus();
+  };
+
+  return (
+    <tr className="sr-only">
+      <td
+        id={`a11y-${uniqueID}-${holdingIndex}`}
+        tabIndex={-1}
+        ref={(el) => {
+          focusNewA11yRow(el, holdingIndex);
+        }}
+      >
+        {holdingsPageHeading(holdingIndex)}
+
+        {prevA11yIndex(holdingIndex) !== null && (
+          <button
+            type="button"
+            onClick={() => {
+              updateA11yFocus(prevA11yIndex(holdingIndex));
+            }}
+          >
+            Previous
+          </button>
+        )}
+
+        {nextA11yIndex(holdingIndex) !== null && (
+          <button
+            type="button"
+            onClick={() => {
+              updateA11yFocus(nextA11yIndex(holdingIndex));
+            }}
+          >
+            Next
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+// eslint-react: defines valid prop types passed to this component
+A11yRow.propTypes = {
+  lastA11yIndex: PropTypes.number,
+  holdingIndex: PropTypes.number,
+  initialVisibleCount: PropTypes.number,
+  pageSize: PropTypes.number,
+  uniqueID: PropTypes.string,
+  visibleHoldingsCount: PropTypes.number,
+};
+
+export default A11yRow;

--- a/app/javascript/availability/components/availability.jsx
+++ b/app/javascript/availability/components/availability.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Fragment, useState } from 'react';
+import A11yRow from './a11y_row';
 import HoldingDetails from './holding_details';
 import SummaryHoldings from './summary_holdings';
 import ViewMoreButton from './view_more_button';
@@ -24,10 +25,15 @@ const Availability = ({ structuredHoldings, summaryHoldings }) => (
           ? holdings.slice(initialVisibleCount)
           : []
       );
-      const [a11yIndex, setA11yIndex] = useState(0);
+      const [lastA11yIndex, setLastA11yIndex] = useState(0);
+
+      const showA11yRow = (holdingIndex) =>
+        holdings.length > initialVisibleCount &&
+        (holdingIndex === 0 ||
+          (holdingIndex - initialVisibleCount) % pageSize === 0);
 
       const viewMore = () => {
-        setA11yIndex(visibleHoldings.length);
+        setLastA11yIndex(visibleHoldings.length);
         setVisibleHoldings([
           ...visibleHoldings,
           ...moreHoldings.slice(0, pageSize),
@@ -57,19 +63,15 @@ const Availability = ({ structuredHoldings, summaryHoldings }) => (
 
               {visibleHoldings.map((holding, holdingIndex) => (
                 <Fragment key={holdingIndex}>
-                  {a11yIndex > 0 && holdingIndex === a11yIndex && (
-                    <tr className="sr-only">
-                      <td
-                        tabIndex={-1}
-                        ref={(el) => {
-                          if (el) {
-                            el.focus();
-                          }
-                        }}
-                      >
-                        More Holdings
-                      </td>
-                    </tr>
+                  {showA11yRow(holdingIndex) && (
+                    <A11yRow
+                      lastA11yIndex={lastA11yIndex}
+                      holdingIndex={holdingIndex}
+                      initialVisibleCount={initialVisibleCount}
+                      pageSize={pageSize}
+                      uniqueID={uniqueID}
+                      visibleHoldingsCount={visibleHoldings.length}
+                    />
                   )}
                   <tr>
                     <HoldingDetails holding={holding} />

--- a/app/javascript/availability/components/view_more_button.jsx
+++ b/app/javascript/availability/components/view_more_button.jsx
@@ -1,22 +1,14 @@
 import PropTypes from 'prop-types';
 
-const ViewMoreButton = ({ uniqueID }) => (
-  <button
-    className="btn btn-primary toggle-more"
-    type="button"
-    data-type="view-more-holdings"
-    data-target={`#collapseHoldings${uniqueID}`}
-    data-toggle="collapse"
-    aria-expanded="false"
-    aria-controls={`#collapseHoldings${uniqueID}`}
-  >
+const ViewMoreButton = ({ onClick }) => (
+  <button className="btn btn-primary mb-3" type="button" onClick={onClick}>
     View More
   </button>
 );
 
 // eslint-react: defines valid prop types passed to this component
 ViewMoreButton.propTypes = {
-  uniqueID: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default ViewMoreButton;

--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -27,23 +27,6 @@ const availability = {
     'https://libraries.psu.edu/about/libraries/donald-w-hamer-center-maps-and-' +
     'geospatial-information/map-scanning-and-printing',
 
-  executeAvailability() {
-    availability.loadAvailability();
-
-    $('.availability').on(
-      'click',
-      '[data-type=view-more-holdings]',
-      function () {
-        $(this).toggleClass('toggle-more');
-        if ($(this).hasClass('toggle-more')) {
-          $(this).text('View More');
-        } else {
-          $(this).text('View Less');
-        }
-      }
-    );
-  },
-
   /**
    * Load real time holdings and availability info from Sirsi Web Services
    */

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 document.addEventListener('turbolinks:load', () => {
-  availability.executeAvailability();
+  availability.loadAvailability();
   bookCovers.start();
   search.autoPlaceholder();
   Blacklight.doBookmarkToggleBehavior();

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -225,9 +225,9 @@ RSpec.feature 'Availability', :vcr, type: :feature do
         within 'div[data-library="UP-PAT"]' do
           expect(page).to have_selector 'button', text: /View More/
           expect(page).not_to have_selector 'button', text: /View Less/
-          expect(page).to have_xpath './/tbody/tr', count: 5
+          expect(page).to have_xpath './/tbody/tr', count: 6
           click_button('View More')
-          expect(page).to have_xpath './/tbody/tr', count: 78
+          expect(page).to have_xpath './/tbody/tr', count: 79
           expect(page).not_to have_selector 'button', text: /View More/
         end
       end

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -227,10 +227,8 @@ RSpec.feature 'Availability', :vcr, type: :feature do
           expect(page).not_to have_selector 'button', text: /View Less/
           expect(page).to have_xpath './/tbody/tr', count: 5
           click_button('View More')
-          expect(page).to have_xpath './/tbody/tr', count: 77
-          expect(page).to have_selector 'button', text: /View Less/
-          click_button('View Less')
-          expect(page).to have_xpath './/tbody/tr', count: 5
+          expect(page).to have_xpath './/tbody/tr', count: 78
+          expect(page).not_to have_selector 'button', text: /View More/
         end
       end
     end
@@ -428,8 +426,7 @@ RSpec.feature 'Availability', :vcr, type: :feature do
           expect(page).to have_xpath './/tbody/tr[td//text()[contains(., \'Request scan\')]]', count: 4
           click_button('View More')
           expect(page).to have_xpath './/tbody/tr[td//text()[contains(., \'Request scan\')]]', count: 50
-          click_button('View Less')
-          expect(page).to have_xpath './/tbody/tr[td//text()[contains(., \'Request scan\')]]', count: 4
+          expect(page).not_to have_selector 'button', text: /View More/
         end
       end
     end

--- a/spec/javascript/availability/components/a11y_row.jsx.spec.js
+++ b/spec/javascript/availability/components/a11y_row.jsx.spec.js
@@ -1,0 +1,177 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import A11yRow from '../../../../app/javascript/availability/components/a11y_row';
+
+describe('when the A11yRow is at index 0 and only the initial set of holdings are visible', () => {
+  test('does not render navigation buttons', () => {
+    const { queryByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={0}
+            holdingIndex={0}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={4}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(queryByRole('button')).toBeNull();
+  });
+});
+
+describe('when the A11yRow is at index 0 and there are more pages of holdings', () => {
+  test('renders a next button but no previous button', () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={0}
+            holdingIndex={0}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={75}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(getByRole('button')).toHaveTextContent('Next');
+  });
+});
+
+describe('when the A11yRow is at index === initialVisibleCount and there are no more pages of holdings', () => {
+  test('renders a previous button but no next button', () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={4}
+            holdingIndex={4}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={75}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(getByRole('button')).toHaveTextContent('Previous');
+  });
+});
+
+describe('when the A11yRow is at index === initialVisibleCount and there are more pages of holdings', () => {
+  test('renders a previous button and a next button', () => {
+    const { queryAllByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={4}
+            holdingIndex={4}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={125}
+          />
+        </tbody>
+      </table>
+    );
+
+    const buttons = queryAllByRole('button');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveTextContent('Previous');
+    expect(buttons[1]).toHaveTextContent('Next');
+  });
+});
+
+describe('when the A11yRow is at the 3rd page of results', () => {
+  test('renders a previous button', () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={104}
+            holdingIndex={104}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={125}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(getByRole('button')).toHaveTextContent('Previous');
+  });
+});
+
+describe('when the previous button is clicked', () => {
+  test('focus moves to the previous A11yRow', () => {
+    const { getByRole, getAllByRole } = render(
+      <table>
+        <tbody>
+          <tr>
+            <td id="a11y-1-0" tabIndex={-1}>
+              A11yRow 0
+            </td>
+          </tr>
+          <A11yRow
+            lastA11yIndex={4}
+            holdingIndex={4}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={75}
+          />
+        </tbody>
+      </table>
+    );
+
+    const tableCells = getAllByRole('cell');
+
+    expect(tableCells).toHaveLength(2);
+    expect(tableCells[1]).toHaveFocus();
+
+    fireEvent.click(getByRole('button'));
+
+    expect(tableCells[0]).toHaveFocus();
+  });
+});
+
+describe('when the next button is clicked', () => {
+  test('focus moves to the next A11yRow', () => {
+    const { getByRole, getAllByRole } = render(
+      <table>
+        <tbody>
+          <A11yRow
+            lastA11yIndex={0}
+            holdingIndex={0}
+            initialVisibleCount={4}
+            pageSize={100}
+            uniqueID="1"
+            visibleHoldingsCount={75}
+          />
+          <tr>
+            <td id="a11y-1-4" tabIndex={-1}>
+              A11yRow 4
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const tableCells = getAllByRole('cell');
+
+    expect(tableCells).toHaveLength(2);
+    expect(tableCells[1]).not.toHaveFocus();
+
+    fireEvent.click(getByRole('button'));
+
+    expect(tableCells[1]).toHaveFocus();
+  });
+});

--- a/spec/javascript/availability/components/availability.jsx.spec.js
+++ b/spec/javascript/availability/components/availability.jsx.spec.js
@@ -1,0 +1,105 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Availability from '../../../../app/javascript/availability/components/availability';
+
+describe('when the record has less than 5 holdings', () => {
+  const structuredHoldings = [
+    {
+      summary: {},
+      holdings: [
+        { catkey: 1, callNumber: 'CallNum1' },
+        { catkey: 2, callNumber: 'CallNum2' },
+        { catkey: 3, callNumber: 'CallNum3' },
+        { catkey: 4, callNumber: 'CallNum4' },
+      ],
+    },
+  ];
+
+  test('does not show the view more button', () => {
+    const { queryByRole } = render(
+      <Availability structuredHoldings={structuredHoldings} />
+    );
+
+    expect(queryByRole('button')).toBeNull();
+  });
+});
+
+describe('when the record has 5 or more holdings', () => {
+  const structuredHoldings = [
+    {
+      summary: {},
+      holdings: [
+        { catkey: 1, callNumber: 'CallNum1' },
+        { catkey: 2, callNumber: 'CallNum2' },
+        { catkey: 3, callNumber: 'CallNum3' },
+        { catkey: 4, callNumber: 'CallNum4' },
+        { catkey: 5, callNumber: 'CallNum5' },
+      ],
+    },
+  ];
+
+  test('shows the view more button', () => {
+    const { getByRole } = render(
+      <Availability structuredHoldings={structuredHoldings} />
+    );
+
+    expect(getByRole('button')).toHaveTextContent('View More');
+  });
+
+  test('expands the visible holdings + hides the View More button when it is clicked', () => {
+    const { getByRole, getByText, queryByText, queryByRole, queryAllByRole } =
+      render(<Availability structuredHoldings={structuredHoldings} />);
+
+    expect(queryAllByRole('row')).toHaveLength(5);
+    expect(queryByText('More Holdings')).toBeNull();
+    expect(queryByText('CallNum5')).toBeNull();
+
+    fireEvent.click(getByRole('button'));
+
+    expect(queryByRole('button')).toBeNull();
+    expect(queryAllByRole('row')).toHaveLength(7);
+    expect(getByText('More Holdings')).toBeInTheDocument();
+    expect(getByText('CallNum5')).toBeInTheDocument();
+  });
+});
+
+describe('when the record has summary holdings', () => {
+  test('shows the summmary holdings info', () => {
+    const structuredHoldings = [
+      {
+        summary: { libraryID: 'UP-PAT' },
+        holdings: [
+          { catkey: 1, callNumber: 'CallNum1' },
+          { catkey: 2, callNumber: 'CallNum2' },
+          { catkey: 3, callNumber: 'CallNum3' },
+          { catkey: 4, callNumber: 'CallNum4' },
+        ],
+      },
+    ];
+
+    const summaryHoldings = {
+      'UP-PAT': {
+        'PATTEE-3': [
+          {
+            call_number: 'PR9400 .M43',
+            summary: ['v.67:no.3(2008)-To Date.'],
+            supplement: ['supplemental info'],
+            index: ['index info'],
+          },
+        ],
+      },
+    };
+
+    const { getAllByRole } = render(
+      <Availability
+        structuredHoldings={structuredHoldings}
+        summaryHoldings={summaryHoldings}
+      />
+    );
+
+    const headings = getAllByRole('heading', { level: 6 });
+    expect(headings[0]).toHaveTextContent(
+      'Pattee - Stacks 3: Holdings Summary'
+    );
+  });
+});

--- a/spec/javascript/availability/components/availability.jsx.spec.js
+++ b/spec/javascript/availability/components/availability.jsx.spec.js
@@ -7,20 +7,21 @@ describe('when the record has less than 5 holdings', () => {
     {
       summary: {},
       holdings: [
-        { catkey: 1, callNumber: 'CallNum1' },
-        { catkey: 2, callNumber: 'CallNum2' },
-        { catkey: 3, callNumber: 'CallNum3' },
-        { catkey: 4, callNumber: 'CallNum4' },
+        { catkey: '1', callNumber: 'CallNum1' },
+        { catkey: '2', callNumber: 'CallNum2' },
+        { catkey: '3', callNumber: 'CallNum3' },
+        { catkey: '4', callNumber: 'CallNum4' },
       ],
     },
   ];
 
-  test('does not show the view more button', () => {
-    const { queryByRole } = render(
+  test('does not show the view more button or accessibility controls', () => {
+    const { queryByRole, queryByText } = render(
       <Availability structuredHoldings={structuredHoldings} />
     );
 
     expect(queryByRole('button')).toBeNull();
+    expect(queryByText('Holdings 1 - 4')).toBeNull();
   });
 });
 
@@ -29,37 +30,45 @@ describe('when the record has 5 or more holdings', () => {
     {
       summary: {},
       holdings: [
-        { catkey: 1, callNumber: 'CallNum1' },
-        { catkey: 2, callNumber: 'CallNum2' },
-        { catkey: 3, callNumber: 'CallNum3' },
-        { catkey: 4, callNumber: 'CallNum4' },
-        { catkey: 5, callNumber: 'CallNum5' },
+        { catkey: '1', callNumber: 'CallNum1' },
+        { catkey: '2', callNumber: 'CallNum2' },
+        { catkey: '3', callNumber: 'CallNum3' },
+        { catkey: '4', callNumber: 'CallNum4' },
+        { catkey: '5', callNumber: 'CallNum5' },
       ],
     },
   ];
 
-  test('shows the view more button', () => {
-    const { getByRole } = render(
+  test('shows the view more button and accessibility controls', () => {
+    const { getByRole, queryByText } = render(
       <Availability structuredHoldings={structuredHoldings} />
     );
 
     expect(getByRole('button')).toHaveTextContent('View More');
+    expect(queryByText('Holdings 1 - 4')).toBeInTheDocument();
   });
 
-  test('expands the visible holdings + hides the View More button when it is clicked', () => {
-    const { getByRole, getByText, queryByText, queryByRole, queryAllByRole } =
-      render(<Availability structuredHoldings={structuredHoldings} />);
+  describe('when the view more button is clicked', () => {
+    test('expands visible holdings + updates a11y elements', () => {
+      const { getByRole, getAllByRole, queryByText, queryAllByRole } = render(
+        <Availability structuredHoldings={structuredHoldings} />
+      );
 
-    expect(queryAllByRole('row')).toHaveLength(5);
-    expect(queryByText('More Holdings')).toBeNull();
-    expect(queryByText('CallNum5')).toBeNull();
+      expect(queryAllByRole('row')).toHaveLength(6);
+      expect(queryByText('Holdings 5 - 5')).toBeNull();
+      expect(queryByText('CallNum5')).toBeNull();
 
-    fireEvent.click(getByRole('button'));
+      fireEvent.click(getByRole('button'));
 
-    expect(queryByRole('button')).toBeNull();
-    expect(queryAllByRole('row')).toHaveLength(7);
-    expect(getByText('More Holdings')).toBeInTheDocument();
-    expect(getByText('CallNum5')).toBeInTheDocument();
+      expect(queryAllByRole('row')).toHaveLength(8);
+      expect(queryByText('Holdings 5 - 5')).toBeInTheDocument();
+      expect(queryByText('CallNum5')).toBeInTheDocument();
+
+      const buttons = getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]).toHaveTextContent('Next');
+      expect(buttons[1]).toHaveTextContent('Previous');
+    });
   });
 });
 

--- a/spec/javascript/availability/components/view_more_button.jsx.spec.js
+++ b/spec/javascript/availability/components/view_more_button.jsx.spec.js
@@ -1,0 +1,12 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ViewMoreButton from '../../../../app/javascript/availability/components/view_more_button';
+
+test('calls the onClick handler when the button is clicked', () => {
+  const onClickSpy = jest.fn();
+  const { getByRole } = render(<ViewMoreButton onClick={onClickSpy} />);
+
+  fireEvent.click(getByRole('button'));
+
+  expect(onClickSpy).toHaveBeenCalled();
+});


### PR DESCRIPTION
Closes #504.

Some items have lots of holdings which can cause the browser to lag or sometimes even crash when it attempts to expand thousands of table rows at once.

In particular, the New York Times is bombing in production. Here it is in the preview branch: https://catalog-view-more.dev.k8s.libraries.psu.edu/catalog/71224