### PR TITLE
Series titles link to series search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -273,7 +273,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'phys_desc_ssm', label: 'Physical Description', top_field: true, if: false, helper_method: :newline_format
     config.add_show_field 'addl_author_display_ssm', label: 'Additional Creators', link_to_facet: :all_authors_facet, top_field: true, if: false
     config.add_show_field 'thesis_dept_facet', label: 'Thesis Department', link_to_facet: :thesis_dept_facet, top_field: true, if: false
-    config.add_show_field 'series_title_display_ssm', label: 'Series', helper_method: :newline_format
+    config.add_show_field 'series_title_display_ssm', label: 'Series', helper_method: :series_links
     config.add_show_field 'language_ssim', label: 'Language'
     config.add_show_field 'language_note_ssm', label: 'Language Note', helper_method: :newline_format
     config.add_show_field 'restrictions_access_note_ssm', label: 'Restrictions on Access', helper_method: :newline_format

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -68,6 +68,18 @@ module CatalogHelper
     content_tag 'ul', result.join(''), nil, false
   end
 
+  # Links to series search for series
+  def series_links(options = {})
+    result = []
+    options[:value].each do |series|
+      lnk = link_to(series,
+                    "/?search_field=series&q=#{CGI.escape series}",
+                    class: 'search-series', title: "Search: #{series}")
+      result << content_tag('li', lnk, nil, false)
+    end
+    content_tag 'ul', result.join(''), nil, false
+  end
+
   # Makes a link to genre full facet
   def genre_links(options = {})
     result = []

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -68,18 +68,6 @@ module CatalogHelper
     content_tag 'ul', result.join(''), nil, false
   end
 
-  # Links to series search for series
-  def series_links(options = {})
-    result = []
-    options[:value].each do |series|
-      lnk = link_to(series,
-                    "/?search_field=series&q=#{CGI.escape series}",
-                    class: 'search-series', title: "Search: #{series}")
-      result << content_tag('li', lnk, nil, false)
-    end
-    content_tag 'ul', result.join(''), nil, false
-  end
-
   # Makes a link to genre full facet
   def genre_links(options = {})
     result = []
@@ -110,6 +98,19 @@ module CatalogHelper
       link_to json['text'], json['url']
     end
     content_tag 'span', contents.join('<br>'), nil, false
+  end
+
+  # Links to series search for series
+  def series_links(options = {})
+    strict_titles = options[:document][:series_title_strict_tsim] || []
+    result = []
+    options[:value].zip(strict_titles).each do |series, strict_title|
+      lnk = link_to(series,
+                    "/?search_field=series&q=#{CGI.escape(strict_title || series)}",
+                    class: 'search-series', title: "Search: #{strict_title || series}")
+      result << content_tag('li', lnk, nil, false)
+    end
+    content_tag 'ul', result.join(''), nil, false
   end
 
   # To render format icon on search results as the default thumbnail for now

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe CatalogHelper, type: :helper do
     context 'when there is a single url and text pair' do
       it 'assembles all the link correctly' do
         link = generic_link link_doc
-        expect(link).to eql '<span><a href="http://usacac.army.mil/CAC2/MilitaryReview/mrpast2.asp">usacac.arm'\
-                            'y.mil</a></span>'
+        expect(link).to eql '<span><a href="http://usacac.army.mil/CAC2/MilitaryReview/mrpast2.asp">'\
+                            'usacac.army.mil</a></span>'
       end
     end
   end
@@ -142,15 +142,16 @@ RSpec.describe CatalogHelper, type: :helper do
 
       it 'assembles the link correctly' do
         link = series_links link_doc
-        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering, 1876-11'\
-                      '00 ; 554" href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering%2C+1876-110'\
-                      '0+%3B+554">Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
+        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering, 1876-1'\
+                      '100 ; 554" href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering%2C+1876-11'\
+                      '00+%3B+554">Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
         expect(link).to eql link_expect
       end
     end
 
     context 'when there are multiple series values and strict versions of the series title' do
       let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
+
       before do
         series_data << 'Series Title 2, 1999, abc123'
         series_title_strict_data << 'Series Title 2'

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -121,6 +121,53 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
+  describe '#series_links' do
+    let (:series_data) { ['Lecture Notes in Electrical Engineering, 1876-1100 ; 554'] }
+    let (:series_title_strict_data) { ['Lecture Notes in Electrical Engineering'] }
+
+    context 'when there is a series value and a strict version of the series title' do
+      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        expect(link).to eql '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical '\
+                                     'Engineering" '\
+                                     'href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">'\
+                                     'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
+      end
+    end
+
+    context 'when there is a series value but no strict version of the series title' do
+      let (:link_doc) { { value: series_data, document: {} } }
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering, 1876-11'\
+                      '00 ; 554" href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering%2C+1876-110'\
+                      '0+%3B+554">Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
+        expect(link).to eql link_expect
+      end
+    end
+
+    context 'when there are multiple series values and strict versions of the series title' do
+      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
+      before do
+        series_data << 'Series Title 2, 1999, abc123'
+        series_title_strict_data << 'Series Title 2'
+      end
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering"'\
+                      ' href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">'\
+                      'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li><li><a class="search-series"'\
+                      ' title="Search: Series Title 2" href="/?search_field=series&amp;q=Series+Title+2">Series '\
+                      'Title 2, 1999, abc123</a></li></ul>'
+        expect(link).to eql link_expect
+      end
+    end
+  end
+
   describe '#render_thumbnail' do
     let (:document) { { format: ['Book'] } }
 


### PR DESCRIPTION
Uses `series_title_strict_tsim` (https://github.com/psu-libraries/psulib_traject/pull/396) when creating the links so the search only uses the 490a or 440a title in the search.  The other series_title fields include the extra stuff like # of the book in the series appended to the end.  These things mess up the search.

closes #537 

linked: https://github.com/psu-libraries/psulib_traject/pull/396