### PR TITLE
user login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :http_header_authenticatable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   # Method added by Blacklight; Blacklight uses #to_s on your
@@ -13,5 +13,9 @@ class User < ApplicationRecord
   # the account.
   def to_s
     email
+  end
+
+  def password_required?
+    false
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require 'devise/redirect_to_login_failure'
+
+Devise.add_module(:http_header_authenticatable,
+                  strategy: true,
+                  controller: :sessions,
+                  model: 'devise/models/http_header_authenticatable')
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -262,10 +269,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = RedirectToLoginFailure
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
   mount BlacklightAdvancedSearch::Engine => '/'
   mount OkComputer::Engine, at: '/health'
 
+  authenticate :user do
+    get '/login', to: 'application#login', as: :login
+  end
+
   # resource and resources
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns [:searchable, :range_searchable]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,9 @@ datadog:
   enabled: false
   # defaults to Rails.env. override here
   # env: feature-foo
+user_header: HTTP_X_AUTH_REQUEST_EMAIL
+groups_header: HTTP_X_AUTH_REQUEST_GROUPS
+admin_group: umg-up.ul-dev-team
 redis:
   sessions:
     uri: redis://127.0.0.1:6379/3

--- a/lib/devise/models/http_header_authenticatable.rb
+++ b/lib/devise/models/http_header_authenticatable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/http_header_authenticatable'
+
+module Devise
+  module Models
+    module HttpHeaderAuthenticatable
+      extend ActiveSupport::Concern
+    end
+  end
+end

--- a/lib/devise/redirect_to_login_failure.rb
+++ b/lib/devise/redirect_to_login_failure.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RedirectToLoginFailure < Devise::FailureApp
+  def redirect_url
+    '/login'
+  end
+end

--- a/lib/devise/strategies/http_header_authenticatable.rb
+++ b/lib/devise/strategies/http_header_authenticatable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/authenticatable'
+module Devise
+  module Strategies
+    class HttpHeaderAuthenticatable < Authenticatable
+      def authenticate!
+        http_user = remote_user(request.headers)
+        return fail! if http_user.blank?
+
+        user = User.find_or_create_by(email: http_user)
+        success!(user)
+      end
+
+      def valid?
+        remote_user(request.headers).present?
+      end
+
+      def remote_user(headers)
+        headers.fetch(Settings.user_header, nil)
+      end
+    end
+  end
+end
+
+Warden::Strategies.add(:http_header_authenticatable, Devise::Strategies::HttpHeaderAuthenticatable)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApplicationController do
       sign_in user
     end
 
-    it 'does not set a the group' do
+    it 'does not set the group' do
       get :login
       expect(session[:groups]).to eq([])
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,26 +3,73 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController do
+  context 'when given the right headers' do
+    before do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      @request.headers[Settings.user_header] = 'user1234@psu.edu'
+      @request.headers[Settings.groups_header] = Settings.admin_group
+      user = User.new(email: 'user1234@psu.edu')
+      sign_in user
+    end
+
+    it 'sets a the group' do
+      get :login
+      expect(session[:groups]).to include(Settings.admin_group)
+    end
+
+    it 'redirects to index' do
+      get :login
+      expect(response).to redirect_to('/')
+    end
+
+    it 'redirects to home' do
+      @request.env['ORIGINAL_FULLPATH'] = '/home'
+      get :login
+      expect(response).to redirect_to('/home')
+    end
+  end
+
+  context 'when given the wrong headers' do
+    before do
+      user = User.new(email: 'user1234@psu.edu')
+      sign_in user
+    end
+
+    it 'does not set a the group' do
+      get :login
+      expect(session[:groups]).to eq([])
+    end
+
+    it 'redirects to login' do
+      get :login
+      expect(response).to redirect_to('/login')
+    end
+  end
+
   describe '#authorize_profiler' do
     before do
       allow(Rack::MiniProfiler).to receive(:authorize_request)
     end
 
-    context 'when the matomo ID is not 7' do
+    context 'when signed in as admin' do
+      before do
+        request.session[:groups] = [Settings.admin_group]
+      end
+
       specify do
-        expect(Settings.matomo_id).not_to eq(7)
         controller.send(:authorize_profiler)
         expect(Rack::MiniProfiler).to have_received(:authorize_request)
       end
     end
 
-    context 'when the matomo ID is 7' do
+    context 'when not signed in' do
+      before do
+        request.session[:groups] = []
+      end
+
       specify do
-        current = Settings.matomo_id
-        Settings.matomo_id = 7
         controller.send(:authorize_profiler)
         expect(Rack::MiniProfiler).not_to have_received(:authorize_request)
-        Settings.matomo_id = current
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController do
       sign_in user
     end
 
-    it 'sets a the group' do
+    it 'sets the group' do
       get :login
       expect(session[:groups]).to include(Settings.admin_group)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,7 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end
 
 Capybara.register_driver :chrome_headless do |app|


### PR DESCRIPTION
Fixes #836 

Adds ability to support penn state users as well as guest users, right now logins aren't intended for general public use, so we've hidden the 'login' behind a `/login` route. once logged in, we pull user email, and groups from our oauth-proxy, we can use this information to allow admins to do adminy things in the future. right now it drives weather or not mini-profiler is shown 

To use locally, we have to set the HTTP header `X_AUTH_REQUEST_EMAIL` in our browser. I'm using mod-headers for testing 
<img width="598" alt="Screen Shot 2022-04-05 at 4 51 58 PM" src="https://user-images.githubusercontent.com/3694886/161847081-38e5bf9c-8c66-4ac3-bf6b-f525f9767105.png">


We might want to, eventually, support a `/logout` route, and maybe in the future wrap things like `bookmarks` in a `if current_user` block? I'm thinking out loud on those. 

As another PR, I may want to code up an /admin interface, where we can maybe do things like set banners, index records, etc. 





