### PR TITLE
Use I18n.t! to raise errors if translations are missing in tests

### DIFF
--- a/spec/components/external_links/hathi_links_component.html.erb_spec.rb
+++ b/spec/components/external_links/hathi_links_component.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ExternalLinks::HathiLinksComponent, type: :component do
     context 'when hathi_links is open_ht_access but not an etas_item' do
       let(:hathi_links) {
         {
-          text: I18n.t('blackcat.hathitrust.public_domain_text'),
+          text: I18n.t!('blackcat.hathitrust.public_domain_text'),
           url: 'https://catalog.hathitrust.org/Record/12345',
           additional_text: nil,
           etas_item: false,
@@ -24,17 +24,17 @@ RSpec.describe ExternalLinks::HathiLinksComponent, type: :component do
       it 'renders a hathi logo linked to hathi record with correct text' do
         expect(rendered).to have_link(href: 'https://catalog.hathitrust.org/Record/12345')
           .and have_css("img[src*='HathiTrust_logo']")
-          .and have_text(I18n.t('blackcat.hathitrust.public_domain_text'))
-        expect(rendered).not_to have_content(I18n.t('blackcat.hathitrust.etas_additional_text'))
+          .and have_text(I18n.t!('blackcat.hathitrust.public_domain_text'))
+        expect(rendered).not_to have_content(I18n.t!('blackcat.hathitrust.etas_additional_text'))
       end
     end
 
     context 'when hathi_links is open_ht_access and an etas_item' do
       let(:hathi_links) {
         {
-          text: I18n.t('blackcat.hathitrust.etas_text'),
+          text: I18n.t!('blackcat.hathitrust.etas_text'),
           url: 'https://catalog.hathitrust.org/Record/12345',
-          additional_text: I18n.t('blackcat.hathitrust.etas_additional_text'),
+          additional_text: I18n.t!('blackcat.hathitrust.etas_additional_text'),
           etas_item: true,
           open_ht_access: true
         }
@@ -43,8 +43,8 @@ RSpec.describe ExternalLinks::HathiLinksComponent, type: :component do
       it 'renders a hathi logo linked to hathi record with correct text' do
         expect(rendered).to have_link(href: 'https://catalog.hathitrust.org/Record/12345')
           .and have_css("img[src*='HathiTrust_logo']")
-          .and have_text(I18n.t('blackcat.hathitrust.etas_text'))
-        expect(rendered).to have_content(I18n.t('blackcat.hathitrust.etas_additional_text'))
+          .and have_text(I18n.t!('blackcat.hathitrust.etas_text'))
+        expect(rendered).to have_content(I18n.t!('blackcat.hathitrust.etas_additional_text'))
         expect(rendered).to have_content('Full Text available online')
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe ExternalLinks::HathiLinksComponent, type: :component do
     let(:show_hathi_links) { false }
     let(:hathi_links) {
       {
-        text: I18n.t('blackcat.hathitrust.public_domain_text'),
+        text: I18n.t!('blackcat.hathitrust.public_domain_text'),
         url: 'https://catalog.hathitrust.org/Record/12345',
         additional_text: nil,
         etas_item: false,

--- a/spec/components/psul_facet_item_component_spec.rb
+++ b/spec/components/psul_facet_item_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PsulFacetItemComponent, type: :component do
       specify do
         expect(link).to be_nil
         expect(selected_span.text).to eq('Online')
-        expect(selected_span.attributes['title'].value).to eq(I18n.t('blackcat.facet_tooltips.access_facet.online'))
+        expect(selected_span.attributes['title'].value).to eq(I18n.t!('blackcat.facet_tooltips.access_facet.online'))
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe PsulFacetItemComponent, type: :component do
       specify do
         expect(selected_span).to be_nil
         expect(link.text).to eq('Online')
-        expect(link.attributes['title'].value).to eq(I18n.t('blackcat.facet_tooltips.access_facet.online'))
+        expect(link.attributes['title'].value).to eq(I18n.t!('blackcat.facet_tooltips.access_facet.online'))
       end
     end
   end

--- a/spec/models/hathi_links_spec.rb
+++ b/spec/models/hathi_links_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HathiLinks do
         hathi_link = SolrDocument.new(document).hathi_links
 
         expect(hathi_link).to match({
-                                      text: I18n.t('blackcat.hathitrust.public_domain_text'),
+                                      text: I18n.t!('blackcat.hathitrust.public_domain_text'),
                                       url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
                                       additional_text: nil,
                                       etas_item: false,
@@ -56,7 +56,7 @@ RSpec.describe HathiLinks do
         hathi_link = SolrDocument.new(document).hathi_links
 
         expect(hathi_link).to match({
-                                      text: I18n.t('blackcat.hathitrust.public_domain_text'),
+                                      text: I18n.t!('blackcat.hathitrust.public_domain_text'),
                                       url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html',
                                       additional_text: nil,
                                       etas_item: false,
@@ -70,9 +70,9 @@ RSpec.describe HathiLinks do
         hathi_link = SolrDocument.new(document).hathi_links
 
         expect(hathi_link).to match({
-                                      text: I18n.t('blackcat.hathitrust.etas_text'),
+                                      text: I18n.t!('blackcat.hathitrust.etas_text'),
                                       url: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html?urlappend=%3B&signon=swle:urn:mace:incommon:psu.edu',
-                                      additional_text: I18n.t('blackcat.hathitrust.etas_additional_text'),
+                                      additional_text: I18n.t!('blackcat.hathitrust.etas_additional_text'),
                                       etas_item: true,
                                       open_ht_access: false
                                     })

--- a/spec/views/external_links/_index_external_links.html.erb_spec.rb
+++ b/spec/views/external_links/_index_external_links.html.erb_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'external_links/index_external_links', type: :view do
 
       expect(rendered).to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
         .and have_css("img[src*='HathiTrust_logo']")
-        .and include(I18n.t('blackcat.hathitrust.public_domain_text'))
+        .and include(I18n.t!('blackcat.hathitrust.public_domain_text'))
     end
 
     it 'does not render Hathi links when show_hathi_links is false' do
@@ -98,7 +98,7 @@ RSpec.describe 'external_links/index_external_links', type: :view do
 
       expect(rendered).not_to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
       expect(rendered).not_to have_css("img[src*='HathiTrust_logo']")
-      expect(rendered).not_to include(I18n.t('blackcat.hathitrust.public_domain_text'))
+      expect(rendered).not_to include(I18n.t!('blackcat.hathitrust.public_domain_text'))
     end
   end
 end

--- a/spec/views/external_links/_show_external_links.html.erb_spec.rb
+++ b/spec/views/external_links/_show_external_links.html.erb_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'external_links/show_external_links', type: :view do
 
       expect(rendered).to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
         .and have_css("img[src*='HathiTrust_logo']")
-        .and include(I18n.t('blackcat.hathitrust.public_domain_text'))
+        .and include(I18n.t!('blackcat.hathitrust.public_domain_text'))
     end
 
     it 'does not render Hathi links when show_hathi_links is false' do
@@ -99,7 +99,7 @@ RSpec.describe 'external_links/show_external_links', type: :view do
 
       expect(rendered).not_to have_link(href: 'https://catalog.hathitrust.org/api/volumes/oclc/12345.html')
       expect(rendered).not_to have_css("img[src*='HathiTrust_logo']")
-      expect(rendered).not_to include(I18n.t('blackcat.hathitrust.public_domain_text'))
+      expect(rendered).not_to include(I18n.t!('blackcat.hathitrust.public_domain_text'))
     end
   end
 end


### PR DESCRIPTION
Closes #775.

If any of the translation keys used in our tests get deleted, the tests reading those keys will fail and let us know something is wrong.