### PR TITLE
Remove Thesis Department faceting/display from catalog config

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,12 +83,11 @@ class CatalogController < ApplicationController
     config.advanced_search[:url_key] ||= 'advanced'
     config.advanced_search[:query_parser] ||= 'edismax'
     config.advanced_search[:form_solr_parameters] ||= {
-      'facet.field' => %w[access_facet format language_facet media_type_facet thesis_dept_facet library_facet location_facet lc_1letter_facet],
+      'facet.field' => %w[access_facet format language_facet media_type_facet library_facet location_facet lc_1letter_facet],
       'facet.pivot' => '',
       'facet.limit' => -1,
       'f.language_facet.facet.limit' => -1,
       'f.format.facet.limit' => -1,
-      'f.thesis_dept_facet.facet.limit' => -1,
       'facet.sort' => 'index'
     }
     config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'
@@ -189,7 +188,6 @@ class CatalogController < ApplicationController
                              show: "\uf0fe", # same as '<i class="fa fa-plus-square" aria-hidden="true"></i>',
                              hide: "\uf146"
                            }
-    config.add_facet_field 'thesis_dept_facet', label: 'Thesis Department', limit: true
 
     #
     # Facets that are configured but are not in the solr response
@@ -272,7 +270,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'edition_display_ssm', label: 'Edition', top_field: true, if: false, helper_method: :newline_format
     config.add_show_field 'phys_desc_ssm', label: 'Physical Description', top_field: true, if: false, helper_method: :newline_format
     config.add_show_field 'addl_author_display_ssm', label: 'Additional Creators', link_to_facet: :all_authors_facet, top_field: true, if: false
-    config.add_show_field 'thesis_dept_facet', label: 'Thesis Department', link_to_facet: :thesis_dept_facet, top_field: true, if: false
     config.add_show_field 'series_title_display_ssm', label: 'Series', helper_method: :series_links
     config.add_show_field 'language_ssim', label: 'Language'
     config.add_show_field 'language_note_ssm', label: 'Language Note', helper_method: :newline_format


### PR DESCRIPTION
The Thesis Department data is not ready for prime time yet, so we need to revert this feature until the underlying data is in a better state.