### PR TITLE
Availability: Change Summary Holdings h6 elements to divs

### DIFF
--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -21,7 +21,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
 
           return (
             <React.Fragment key={locationID}>
-              <h6>{locationName}: Holdings Summary</h6>
+              <div className="h6">{locationName}: Holdings Summary</div>
 
               <ul style={listStyle}>
                 {/* Summaries */}
@@ -32,10 +32,10 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                 {/* Indexes */}
                 {locationData.index.length > 0 && (
                   <li>
-                    <h6 className="mt-2">
+                    <div className="h6 mt-2">
                       <span className="sr-only">{locationName}</span>
                       Indexes
-                    </h6>
+                    </div>
 
                     <ul style={listStyle}>
                       {locationData.index.map((index, i) => (
@@ -48,10 +48,10 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                 {/* Supplements */}
                 {locationData.supplement.length > 0 && (
                   <li>
-                    <h6 className="mt-2">
+                    <div className="h6 mt-2">
                       <span className="sr-only">{locationName}</span>
                       Supplements
-                    </h6>
+                    </div>
 
                     <ul style={listStyle}>
                       {locationData.supplement.map((supplement, i) => (

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Availability', :vcr, type: :feature do
     it 'that has summary holdings information' do
       visit '/?utf8=✓&search_field=all_fields&q=1793712'
       click_button('View Availability')
-      expect(page).to have_selector 'tr.table-primary h6', text: 'Stacks - General Collection: Holdings Summary'
+      expect(page).to have_selector 'tr.table-primary .h6', text: 'Stacks - General Collection: Holdings Summary'
     end
 
     context 'when Hathi ETAS is enabled' do
@@ -186,7 +186,7 @@ RSpec.feature 'Availability', :vcr, type: :feature do
 
     it 'that has summary holdings information' do
       visit '/catalog/1793712'
-      expect(page).to have_selector 'tr.table-primary h6', text: 'Stacks - General Collection: Holdings Summary'
+      expect(page).to have_selector 'tr.table-primary .h6', text: 'Stacks - General Collection: Holdings Summary'
     end
 
     context 'when HathiTrust ETAS is enabled' do

--- a/spec/javascript/availability/components/availability.jsx.spec.js
+++ b/spec/javascript/availability/components/availability.jsx.spec.js
@@ -99,16 +99,15 @@ describe('when the record has summary holdings', () => {
       },
     };
 
-    const { getAllByRole } = render(
+    const { getByText } = render(
       <Availability
         structuredHoldings={structuredHoldings}
         summaryHoldings={summaryHoldings}
       />
     );
 
-    const headings = getAllByRole('heading', { level: 6 });
-    expect(headings[0]).toHaveTextContent(
-      'Pattee - Stacks 3: Holdings Summary'
-    );
+    expect(
+      getByText('Pattee - Stacks 3: Holdings Summary')
+    ).toBeInTheDocument();
   });
 });

--- a/spec/javascript/availability/components/summary_holdings.jsx.spec.js
+++ b/spec/javascript/availability/components/summary_holdings.jsx.spec.js
@@ -23,7 +23,7 @@ describe('when all summary holdings arrays are populated', () => {
       ],
     };
 
-    const { getAllByRole } = render(
+    const { getAllByRole, getByText } = render(
       <SummaryHoldings summaryHoldings={data} />,
       {
         container: document.body.appendChild(document.createElement('tbody')),
@@ -36,13 +36,11 @@ describe('when all summary holdings arrays are populated', () => {
     expect(items[2]).toHaveTextContent('index info');
     expect(items[4]).toHaveTextContent('supplemental info');
 
-    const headings = getAllByRole('heading', { level: 6 });
-    expect(headings.length).toBe(3);
-    expect(headings[0]).toHaveTextContent(
-      'Pattee - Stacks 3: Holdings Summary'
-    );
-    expect(headings[1]).toHaveTextContent('Indexes');
-    expect(headings[2]).toHaveTextContent('Supplements');
+    expect(
+      getByText('Pattee - Stacks 3: Holdings Summary')
+    ).toBeInTheDocument();
+    expect(getByText('Indexes')).toBeInTheDocument();
+    expect(getByText('Supplements')).toBeInTheDocument();
   });
 });
 
@@ -59,7 +57,7 @@ describe('when some summary holdings data is not present', () => {
       ],
     };
 
-    const { getAllByRole } = render(
+    const { getAllByRole, getByText, queryByText } = render(
       <SummaryHoldings summaryHoldings={data} />,
       {
         container: document.body.appendChild(document.createElement('tbody')),
@@ -70,10 +68,10 @@ describe('when some summary holdings data is not present', () => {
     expect(items.length).toBe(1);
     expect(items[0]).toHaveTextContent('v.67:no.3(2008)-To Date.');
 
-    const headings = getAllByRole('heading', { level: 6 });
-    expect(headings.length).toBe(1);
-    expect(headings[0]).toHaveTextContent(
-      'Pattee - Stacks 3: Holdings Summary'
-    );
+    expect(
+      getByText('Pattee - Stacks 3: Holdings Summary')
+    ).toBeInTheDocument();
+    expect(queryByText('Indexes')).toBeNull();
+    expect(queryByText('Supplements')).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #991.

In screen reader testing with Michelle, we found out that having too many header tags on the page actually made navigation more difficult and confusing. Replacing these headers with `div`s with an `h6` class provides the same visual appearance but makes screen reader navigation easier.