### PR TITLE
Hotfix- Google preview link was still showing when Hathi link was present

### DIFF
--- a/app/components/external_links/google_preview_link_component.rb
+++ b/app/components/external_links/google_preview_link_component.rb
@@ -40,7 +40,8 @@ module ExternalLinks
       end
 
       def hathi_link?
-        document[:ht_access] == 'allow' || (document[:ht_access] == 'deny' && Settings&.hathi_etas)
+        document[:document]['ht_access_ss'] == 'allow' ||
+          (document[:document]['ht_access_ss'] == 'deny' && Settings&.hathi_etas)
       end
 
       attr_reader :document

--- a/spec/components/external_links/google_preview_link_component_spec.rb
+++ b/spec/components/external_links/google_preview_link_component_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ExternalLinks::GooglePreviewLinkComponent, type: :component do
   end
 
   context 'when document has an LCCN, OCLC or ISBN, but is Free to Read' do
-    let(:document) { { 'access_facet' => ['Free to Read', 'In the Library'] } }
+    let(:document) { { 'access_facet' => ['Free to Read', 'In the Library'], 'isbn_valid_ssm' => ['92746'] } }
 
     it 'renders a hidden link with no attached search term data' do
       expect(rendered).to have_css("img[src*='gbs_preview_button1']", visible: :hidden)
@@ -53,7 +53,7 @@ RSpec.describe ExternalLinks::GooglePreviewLinkComponent, type: :component do
   end
 
   context 'when document has an LCCN, OCLC or ISBN, but has a link to a Hathi Trust version' do
-    let(:document) { { 'ht_access' => ['allow'] } }
+    let(:document) { { 'ht_access_ss' => 'allow', 'isbn_valid_ssm' => ['92746'] } }
 
     it 'renders a hidden link with no attached search term data' do
       expect(rendered).to have_css("img[src*='gbs_preview_button1']", visible: :hidden)


### PR DESCRIPTION
I had the document parsing wrong for grabbing the hathi trust access field: 'ht_access_ss'.  I think `document[:document]['ht_access_ss']` should work.  I deleted my setup for getting the hathi stuff locally so I'm having trouble confirming this, though.