### PR TITLE
Fix "Ask a Librarian" widget not showing on bookmarks page.

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,8 +7,6 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import availability from '../availability';
 import bookCovers from '../book_covers';
 import search from '../search';
@@ -19,11 +17,6 @@ import '../blacklight_overrides';
 
 require.context('../psulib_blacklight/images/', true);
 document.addEventListener('DOMContentLoaded', () => {
-  Rails.start();
-  Turbolinks.start();
-});
-
-document.addEventListener('turbolinks:load', () => {
   availability.loadAvailability();
   bookCovers.start();
   search.autoPlaceholder();

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "prop-types": "^15.7.2",
     "rails-ujs": "^5.2.6",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "turbolinks": "^5.2.0"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9718,11 +9718,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
Remove turbolinks stuff and Rails.start in application.js.  Moved all js implementations in application.js to trigger on DOM load.

Preview is here: https://catalog-ask-librarian.dev.k8s.libraries.psu.edu

These changes don't seem to have broken anything, and the tests are passing, so I think the TurboLinks and Rails js stuff is already running with Rails and doesn't need to be handled with node/webpacker.

closes #608 