### PR TITLE
return plain text when format is not html

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,10 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render status: 404
+    respond_to do |format|
+      format.html { render status: 404 }
+      format.all { render plain: 'not found', status: 404 }
+    end
   end
 
   def internal_server_error

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -3,6 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Errors', type: :request do
+  describe 'not found text' do
+    before(:all) { get '/Copernicus.txt' }
+
+    it 'has http status 404' do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns text response' do
+      expect(response.body).to eq('not found')
+    end
+  end
+
   describe 'not found' do
     before (:all) { get '/404' }
 


### PR DESCRIPTION
When a user navigates to a non html path, previously the application would throw a 500 template not found error, instead of a 404. for non html requests, we fall back to rendering plain text, with status of 404. 



Fixes #1010 

