### PR TITLE
Availability: add more component tests + minor cleanups

### DIFF
--- a/app/javascript/availability/components/a11y_nav_button.jsx
+++ b/app/javascript/availability/components/a11y_nav_button.jsx
@@ -16,12 +16,7 @@ const A11yNavButton = ({ index, label, uniqueID }) => {
   }
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        updateA11yFocus();
-      }}
-    >
+    <button type="button" onClick={updateA11yFocus}>
       {label}
     </button>
   );

--- a/app/javascript/availability/components/availability.jsx
+++ b/app/javascript/availability/components/availability.jsx
@@ -81,13 +81,7 @@ const Availability = ({ structuredHoldings, summaryHoldings }) => (
             </tbody>
           </table>
 
-          {moreHoldings.length > 0 && (
-            <ViewMoreButton
-              onClick={() => {
-                viewMore();
-              }}
-            />
-          )}
+          {moreHoldings.length > 0 && <ViewMoreButton onClick={viewMore} />}
         </div>
       );
     })}

--- a/app/javascript/availability/components/course_reserve_due_date.jsx
+++ b/app/javascript/availability/components/course_reserve_due_date.jsx
@@ -30,9 +30,9 @@ const CourseReserveDueDate = ({ holding }) => {
   return (
     <div>
       <strong>Due back at:</strong>
-      {` ${time} on ${day}`}
+      <span>{` ${time} on ${day}`}</span>
       <br />
-      {circulationRule}
+      <span>{circulationRule}</span>
     </div>
   );
 };

--- a/app/javascript/availability/components/snippet.jsx
+++ b/app/javascript/availability/components/snippet.jsx
@@ -7,9 +7,7 @@ const Snippet = ({ data }) => {
     const libraries = [];
 
     data.forEach((d) => {
-      if (d.summary.library === 'ON-ORDER') {
-        libraries.push('');
-      } else {
+      if (d.summary.library !== 'ON-ORDER') {
         libraries.push(d.summary.library);
       }
     });

--- a/spec/javascript/availability/components/course_reserve_due_date.jsx.spec.js
+++ b/spec/javascript/availability/components/course_reserve_due_date.jsx.spec.js
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CourseReserveDueDate from '../../../../app/javascript/availability/components/course_reserve_due_date';
+
+describe('when the item does not have a reserve circulation rule', () => {
+  test('does not render the component', () => {
+    const holdingData = { dueDate: '2019-06-11T12:34' };
+    const { container } = render(
+      <CourseReserveDueDate holding={holdingData} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when the item does not have a due date', () => {
+  test('does not render the component', () => {
+    const holdingData = { reserveCirculationRule: '4WKRESIDNT' };
+    const { container } = render(
+      <CourseReserveDueDate holding={holdingData} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when the item is on course reserve', () => {
+  test('renders the component with the correct due date and circulation rule', () => {
+    const holdingData = {
+      dueDate: '2019-06-11T12:34Z',
+      reserveCirculationRule: '4WKRESIDNT',
+    };
+    const { getByText } = render(
+      <CourseReserveDueDate holding={holdingData} />
+    );
+
+    expect(getByText('Due back at:')).toBeInTheDocument();
+    expect(getByText('8:34 AM on 6/11/2019')).toBeInTheDocument();
+    expect(
+      getByText('Circulates for 28 days, Resident PA users')
+    ).toBeInTheDocument();
+  });
+});

--- a/spec/javascript/availability/components/location_info.jsx.spec.js
+++ b/spec/javascript/availability/components/location_info.jsx.spec.js
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LocationInfo from '../../../../app/javascript/availability/components/location_info';
+
+describe('when the item is not related to ILL or AEON', () => {
+  test('renders an ILL link', () => {
+    const holdingData = { libraryID: 'BEAVER', locationID: 'DISPLAY-BR' };
+    const { getByText } = render(<LocationInfo holding={holdingData} />);
+
+    expect(getByText('Beaver - Display')).toBeInTheDocument();
+  });
+});

--- a/spec/javascript/availability/components/snippet.jsx.spec.js
+++ b/spec/javascript/availability/components/snippet.jsx.spec.js
@@ -1,0 +1,114 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Snippet from '../../../../app/javascript/availability/components/snippet';
+
+describe('when there are no copies of the item available', () => {
+  test('does not render the component', () => {
+    const data = [
+      {
+        holdings: [
+          {
+            totalCopiesAvailable: 0,
+          },
+        ],
+      },
+    ];
+    const { container } = render(<Snippet data={data} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('when there are copies of the item available', () => {
+  describe('when there are more than 2 locations', () => {
+    test('renders the component with the correct text', () => {
+      const data = [
+        {
+          holdings: [
+            {
+              totalCopiesAvailable: 1,
+            },
+          ],
+        },
+        {
+          holdings: [
+            {
+              totalCopiesAvailable: 1,
+            },
+          ],
+        },
+        {
+          holdings: [
+            {
+              totalCopiesAvailable: 1,
+            },
+          ],
+        },
+      ];
+
+      const { getByText } = render(<Snippet data={data} />);
+
+      expect(getByText('Multiple Locations')).toBeInTheDocument();
+    });
+  });
+
+  describe('when there are 2 or fewer locations', () => {
+    test('renders the component with the correct text', () => {
+      const data = [
+        {
+          holdings: [
+            {
+              totalCopiesAvailable: 1,
+            },
+          ],
+          summary: {
+            library: 'Library 1',
+          },
+        },
+        {
+          holdings: [
+            {
+              totalCopiesAvailable: 1,
+            },
+          ],
+          summary: {
+            library: 'Library 2',
+          },
+        },
+      ];
+
+      const { getByText } = render(<Snippet data={data} />);
+
+      expect(getByText('Library 1, Library 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('when one of the locations is ON-ORDER', () => {
+    const data = [
+      {
+        holdings: [
+          {
+            totalCopiesAvailable: 1,
+          },
+        ],
+        summary: {
+          library: 'Library 1',
+        },
+      },
+      {
+        holdings: [
+          {
+            totalCopiesAvailable: 1,
+          },
+        ],
+        summary: {
+          library: 'ON-ORDER',
+        },
+      },
+    ];
+
+    const { getByText } = render(<Snippet data={data} />);
+
+    expect(getByText('Library 1')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Some more tests could still be added to the `LocationInfo` component to get the coverage up, but that would require mocking `AeonLink` and `IllLink` inside the location info tests. For some reason I couldn't get that to work, so I abandoned for now.