### PR TITLE
fix for call number browse next button 

### DIFF
--- a/app/presenters/shelf_list_presenter.rb
+++ b/app/presenters/shelf_list_presenter.rb
@@ -43,7 +43,11 @@ class ShelfListPresenter
   def next_item
     return if last?
 
-    shelf_items.last
+    if first? || nearby_first?(shelf_items)
+      shelf_items[length]
+    else
+      shelf_items[length + 1] || list.last
+    end
   end
 
   def previous_item
@@ -190,7 +194,7 @@ class ShelfListPresenter
     end
 
     def last_page?
-      shelf_list[:after].first.key.first.upcase == query_to_last_page
+      shelf_list[:after].last.key.first.upcase == query_to_last_page
     end
 
     def first?

--- a/spec/presenters/shelf_list_presenter_spec.rb
+++ b/spec/presenters/shelf_list_presenter_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ShelfListPresenter, type: :model do
 
     specify do
       expect(shelf.list.map(&:call_number)).to eq(['first_book', 'middle_book', 'last'])
-      expect(shelf.next_item.call_number).to eq('last')
+      expect(shelf.next_item).to be_nil
       expect(shelf.previous_item.call_number).to eq('previous_shelf')
     end
   end
@@ -178,13 +178,13 @@ RSpec.describe ShelfListPresenter, type: :model do
           .and_return(
             {
               before: [],
-              after: [first, middle_book, last_book, next_shelf]
+              after: [first, last_book, next_shelf]
             }
           )
       end
 
       specify do
-        expect(shelf.list.map(&:call_number)).to eq(['None', 'first', 'middle_book'])
+        expect(shelf.list.map(&:call_number)).to eq(['None', 'first', 'last_book'])
         expect(shelf.next_item.call_number).to eq('next_shelf')
         expect(shelf.previous_item).to be_nil
         expect(shelf.list[0]).to be_nearby


### PR DESCRIPTION
next button was selecting the last item before slicing to length, which was causing paging to jump further than we want