### PR TITLE
Remove CJKBigramFilterFactory out

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -454,8 +454,6 @@
         <filter class="solr.ICUTransformFilterFactory" id="Traditional-Simplified"/>
         <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana" />
         <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.CJKBigramFilterFactory"
-                han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="true"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
CJKBigramFilterFactory seems to be costly for our Solr instance due to generating too many bigrams of CJK terms

We will test CJK search results without this filter and see if the results are acceptable.