### PR TITLE
override 5xx error message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Layout/LineLength:
   Exclude:
   # The catalog controller is just one giant block for config.
   - 'app/controllers/catalog_controller.rb'
+  - 'spec/controllers/catalog_controller_spec.rb'
 
 Lint/MissingSuper:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,7 @@ RSpec/AnyInstance:
 RSpec/RepeatedExampleGroupBody:
   Exclude:
   - 'spec/features/google_preview_link_spec.rb'
+
+RSpec/MessageSpies:
+  Exclude:
+  - 'spec/controllers/catalog_controller_spec.rb'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -14,6 +14,8 @@ en:
       librarian_view: 'MARC View'
       sms: 'SMS'
     search:
+      errors:
+        request_error: "Sorry, our search index experienced a problem. Please try again in a moment. If this error persists, please [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology."
       librarian_view:
         title: 'MARC View'
       facets:

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  context 'when there is an invalid search', api: false do
+  context 'when there is an invalid search' do
     let(:service) { instance_double(Blacklight::SearchService) }
     let(:fake_error) { Blacklight::Exceptions::InvalidRequest.new }
 
@@ -48,7 +48,7 @@ RSpec.describe CatalogController, type: :controller do
       expect(controller.logger).to receive(:error).with(fake_error)
       get :index, params: { q: '+' }
       expect(response.redirect_url).to eq root_url
-      expect(request.flash[:notice]).to eq 'Sorry, our search index experienced a problem. Please try again in a moment. If this error persists, please [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology.'
+      expect(request.flash[:notice]).to eq I18n.t('blacklight.search.errors.request_error')
       expect(response).not_to be_successful
       expect(response).to have_http_status :found
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  context "when there is an invalid search", api: false do
+  context 'when there is an invalid search', api: false do
     let(:service) { instance_double(Blacklight::SearchService) }
     let(:fake_error) { Blacklight::Exceptions::InvalidRequest.new }
 
@@ -44,16 +44,18 @@ RSpec.describe CatalogController, type: :controller do
       allow(Rails.env).to receive_messages(test?: false)
     end
 
-    it "redirects the user to the root url for a bad search" do
+    it 'redirects the user to the root url for a bad search' do
       expect(controller.logger).to receive(:error).with(fake_error)
       get :index, params: { q: '+' }
       expect(response.redirect_url).to eq root_url
-      expect(request.flash[:notice]).to eq "Sorry, our search index experienced a problem. Please try again in a moment. If this error persists, please [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology."
+      expect(request.flash[:notice]).to eq 'Sorry, our search index experienced a problem.
+      Please try again in a moment. If this error persists, please
+      [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology.'
       expect(response).not_to be_successful
-      expect(response.status).to eq 302
+      expect(response).to have_http_status :found
     end
 
-    it "returns status 500 if the catalog path is raising an exception" do
+    it 'returns status 500 if the catalog path is raising an exception' do
       allow(controller).to receive(:flash).and_return(notice: I18n.t('blacklight.search.errors.request_error'))
       expect { get :index, params: { q: '+' } }.to raise_error Blacklight::Exceptions::InvalidRequest
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -33,4 +33,29 @@ RSpec.describe CatalogController, type: :controller do
       expect(get: '/catalog/id/marc_view').to route_to(controller: 'catalog', action: 'librarian_view', id: 'id')
     end
   end
+
+  context "when there is an invalid search", api: false do
+    let(:service) { instance_double(Blacklight::SearchService) }
+    let(:fake_error) { Blacklight::Exceptions::InvalidRequest.new }
+
+    before do
+      allow(controller).to receive(:search_service).and_return(service)
+      allow(service).to receive(:search_results) { |*_args| raise fake_error }
+      allow(Rails.env).to receive_messages(test?: false)
+    end
+
+    it "redirects the user to the root url for a bad search" do
+      expect(controller.logger).to receive(:error).with(fake_error)
+      get :index, params: { q: '+' }
+      expect(response.redirect_url).to eq root_url
+      expect(request.flash[:notice]).to eq "Sorry, our search index experienced a problem. Please try again in a moment. If this error persists, please [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology."
+      expect(response).not_to be_successful
+      expect(response.status).to eq 302
+    end
+
+    it "returns status 500 if the catalog path is raising an exception" do
+      allow(controller).to receive(:flash).and_return(notice: I18n.t('blacklight.search.errors.request_error'))
+      expect { get :index, params: { q: '+' } }.to raise_error Blacklight::Exceptions::InvalidRequest
+    end
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -48,9 +48,7 @@ RSpec.describe CatalogController, type: :controller do
       expect(controller.logger).to receive(:error).with(fake_error)
       get :index, params: { q: '+' }
       expect(response.redirect_url).to eq root_url
-      expect(request.flash[:notice]).to eq 'Sorry, our search index experienced a problem.
-      Please try again in a moment. If this error persists, please
-      [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology.'
+      expect(request.flash[:notice]).to eq 'Sorry, our search index experienced a problem. Please try again in a moment. If this error persists, please [report the issue](https://libraries.psu.edu/website-feedback) to Libraries Strategic Technology.'
       expect(response).not_to be_successful
       expect(response).to have_http_status :found
     end


### PR DESCRIPTION
Override blacklight's default search error message
Added 'report a problem' link in new error message
Closes #1059 