### PR TITLE
sidekiq is not used

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,7 +4,6 @@ if Settings.datadog.enabled
   require 'ddtrace'
   Datadog.configure do |c|
     c.use :rails
-    c.use :sidekiq, analytics_enabled: true
     c.use :redis
     c.tracer env: Settings.datadog.env || Rails.env
   end


### PR DESCRIPTION
In testing with `green` i noticed that we are not using sidekiq in the catalog, but we are calling it in the datadog initializer, this is causing some unneeded output in the prod environment 