### PR TITLE
'Ask a Librarian' widget to show on bookmarks

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,8 +7,6 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import availability from '../availability';
 import bookCovers from '../book_covers';
 import search from '../search';
@@ -19,8 +17,6 @@ import '../blacklight_overrides';
 
 require.context('../psulib_blacklight/images/', true);
 document.addEventListener('DOMContentLoaded', () => {
-  Rails.start();
-  Turbolinks.start();
   availability.loadAvailability();
   bookCovers.start();
   search.autoPlaceholder();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,9 +21,6 @@ require.context('../psulib_blacklight/images/', true);
 document.addEventListener('DOMContentLoaded', () => {
   Rails.start();
   Turbolinks.start();
-});
-
-document.addEventListener('turbolinks:load', () => {
   availability.loadAvailability();
   bookCovers.start();
   search.autoPlaceholder();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+import Rails from 'rails-ujs';
 import availability from '../availability';
 import bookCovers from '../book_covers';
 import search from '../search';
@@ -17,6 +18,7 @@ import '../blacklight_overrides';
 
 require.context('../psulib_blacklight/images/', true);
 document.addEventListener('DOMContentLoaded', () => {
+  Rails.start();
   availability.loadAvailability();
   bookCovers.start();
   search.autoPlaceholder();

--- a/spec/features/ask_a_librarian_spec.rb
+++ b/spec/features/ask_a_librarian_spec.rb
@@ -24,5 +24,10 @@ RSpec.describe 'Ask a librarian', type: :feature do
                            wait: 10)
       expect(page).to have_css('button[class^="libchat"]', count: 1)
     end
+
+    it 'shows on the bookmarks page' do
+      visit '/bookmarks'
+      expect(page).to have_css('button[class^="libchat"]', count: 1)
+    end
   end
 end

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Bookmarks', type: :feature do
+  before do
+    stub_request(:any, /hathitrust/).to_return(status: 200, body: '{}', headers: {})
+  end
+
+  it 'Adds, removes, re-adds, and views a bookmarked record', js: true do
+    visit '/?utf8=✓&search_field=all_fields&q=Ethical+and+Social+Issues+in+the+Information+Age+AND+9783319707129'
+    bookmark_buttons = find_all('.toggle-bookmark')
+    bookmark_buttons.first.click
+    sleep 1
+    expect(page).to have_content 'In Bookmarks'
+    bookmark_buttons.first.click
+    sleep 1
+    expect(page).not_to have_content 'In Bookmarks'
+    bookmark_buttons.first.click
+    sleep 1
+    click_link 'Bookmarks'
+    expect(page).to have_css :h1, text: 'Bookmarks'
+    expect(page).to have_content '1 entry found'
+    expect(page).to have_content 'Ethical and Social Issues in the Information Age'
+  end
+end

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -4,7 +4,13 @@ require 'rails_helper'
 
 RSpec.describe 'Bookmarks', type: :feature do
   before do
-    stub_request(:any, /hathitrust/).to_return(status: 200, body: '{}', headers: {})
+    # In Rails 6, CSRF protection is turned off by default in test env
+    # Turning it on here to test that it doesn't break Bookmarks
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  after do
+    ActionController::Base.allow_forgery_protection = false
   end
 
   it 'Adds, removes, re-adds, and views a bookmarked record', js: true do


### PR DESCRIPTION
Afaict these changes have the widget working and the availability stuff is unaffected.  You can check it out here: https://catalog-ask.dev.k8s.libraries.psu.edu

Not sure what was causing the issues with availability before.

closes #608 