### PR TITLE
Sort links

### DIFF
--- a/app/components/external_links/base_links_component.rb
+++ b/app/components/external_links/base_links_component.rb
@@ -36,9 +36,8 @@ module ExternalLinks
       def sorted_links(links_arg)
         return links_arg unless links_arg.is_a?(Array)
 
-        links_arg.sort_by{ |l| l['text'] == 'Special Collections Materials' ? 0 : 1 }
+        links_arg.sort_by { |l| l['text'] == 'Special Collections Materials' ? 0 : 1 }
       end
-
 
       def show_links?
         !!@show_links

--- a/app/components/external_links/base_links_component.rb
+++ b/app/components/external_links/base_links_component.rb
@@ -3,7 +3,7 @@
 module ExternalLinks
   class BaseLinksComponent < ViewComponent::Base
     def initialize(links:, heading: nil, show_links: true)
-      @links = links
+      @links = sorted_links(links)
       @heading = heading
       @show_links = show_links
       @data_target = data_target
@@ -32,6 +32,13 @@ module ExternalLinks
     private
 
       attr_reader :links, :heading
+
+      def sorted_links(links_arg)
+        return links_arg unless links_arg.is_a?(Array)
+
+        links_arg.sort_by{ |l| l['text'] == 'Special Collections Materials' ? 0 : 1 }
+      end
+
 
       def show_links?
         !!@show_links

--- a/spec/components/external_links/base_links_component.html.erb_spec.rb
+++ b/spec/components/external_links/base_links_component.html.erb_spec.rb
@@ -112,4 +112,28 @@ RSpec.describe ExternalLinks::BaseLinksComponent, type: :component do
       expect(rendered).not_to have_selector('#collapseLinksExternalLinks')
     end
   end
+
+  context 'when there are 3 links and one directs to "Special Collections Materials"' do
+    let(:links) {
+      [
+        {
+          text: '2nd link',
+          url: 'url.2'
+        }.with_indifferent_access,
+        {
+          text: '3rd link',
+          url: 'url.3'
+        }.with_indifferent_access,
+        {
+          text: 'Special Collections Materials',
+          url: 'http://n2t.net/ark:/42409/fa812345'
+        }.with_indifferent_access
+      ]
+    }
+
+    it 'displays 3 links with the "Special Collections Materials" first' do
+      expect(rendered.search('li').count).to eq(3)
+      expect(rendered.search('li').first.text).to include('Special Collections Materials')
+    end
+  end
 end


### PR DESCRIPTION
Sorting links so the 'Special Collections Materials' link is at the top.  Depends on https://github.com/psu-libraries/psulib_traject/pull/435.

Closes #1007 