### PR TITLE
500 Error Page

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,8 @@ module Psulcat
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # Use our own custom exceptions
+    config.exceptions_app = routes
   end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -28,14 +28,13 @@ RSpec.describe 'Errors', type: :request do
   end
 
   describe 'internal server error' do
-    before (:all) { get '/500' }
-
-    it 'has http status 500' do
-      expect(response).to have_http_status(:internal_server_error)
-    end
-
-    it 'redirects to customized internal_server_error error page' do
-      expect(response.body).to include("We're sorry, but something went wrong.")
+    it 'has http status 500 and redirects to customized internal_server_error error page' do
+      respond_without_detailed_exceptions do
+        allow(RSolr).to receive(:connect).and_raise(Exception)
+        get '/'
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.body).to include("We're sorry, but something went wrong.")
+      end
     end
   end
 

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Page not found', type: :routing do
+RSpec.describe 'Error Routing', type: :routing do
   it 'routes to page not found if path is completely invalid' do
     expect(get: 'kaljhgl').to route_to controller: 'errors', action: 'not_found', catch_unknown_routes: 'kaljhgl'
+  end
+
+  it 'routes to internal server error if directed to the 500 path' do
+    expect(get: '/500').to route_to controller: 'errors', action: 'internal_server_error'
   end
 end

--- a/spec/support/error_responses.rb
+++ b/spec/support/error_responses.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WithoutDetailedExceptions
+  RSpec.configure do |config|
+    config.include self, type: :request
+  end
+
+  def respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config['action_dispatch.show_exceptions']
+    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_detailed_exceptions'] = false
+    yield
+  ensure
+    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
+    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+  end
+end


### PR DESCRIPTION
I _think_ the issue was that the 500 template wasn't rendering properly.  The configuration I added (mentioned by Adam in the issue) seems to have fixed this.  I could get it to show a blank page locally (like the error in QA) by raising an exception in the Application Controller.  That's the closest I could get to reproducing what was seen in QA.  Adding the configuration makes the 500 template render.  I think we should still try to find a way to reproduce this in QA to confirm.

I added a module to the spec support files that allows a test to run without detailed exceptions.  This is used to test the 500 template rendering when an exception is raised.

closes #853 