### PR TITLE
ILL location links

### DIFF
--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -484,7 +484,8 @@ const availability = {
     return (
       ['UP-MICRO'].includes(holding.libraryID) &&
       holding.homeLocationID !== 'THESIS-NML' &&
-      holding.itemTypeID === 'MICROFORM'
+      holding.itemTypeID === 'MICROFORM' &&
+      !(holding.locationID in availability.illiadLocations)
     );
   },
 

--- a/spec/javascript/availability/components/ill_link.jsx.spec.js
+++ b/spec/javascript/availability/components/ill_link.jsx.spec.js
@@ -71,11 +71,12 @@ describe('when all fields are present', () => {
     availability.reservesScanLocations = [];
   });
 
-  test('renders a microform link', async () => {
+  test('renders a non-ILL microform link', async () => {
     const { getByRole, container } = render(
       <IllLink
         holding={{
-          ...holdingData,
+          callNumber: '123',
+          locationID: 'MFILM-NML',
           libraryID: 'UP-MICRO',
           itemTypeID: 'MICROFORM',
         }}
@@ -83,13 +84,37 @@ describe('when all fields are present', () => {
     );
 
     const microformParams =
-      '&Form=30&isbn=1234&Genre=GenericRequestMicroScan&location=BINDERY';
+      '&Form=30&isbn=1234&Genre=GenericRequestMicroScan&location=MFILM-NML';
     const href = baseUrl + microformParams + moreParams;
 
     await testLink(
       getByRole,
       container,
       'Request Scan - Penn State Users',
+      href
+    );
+  });
+
+  test('renders an ILL microform link', async () => {
+    const { getByRole, container } = render(
+      <IllLink
+        holding={{
+          callNumber: '123',
+          locationID: 'ILL',
+          libraryID: 'UP-MICRO',
+          itemTypeID: 'MICROFORM',
+        }}
+      />
+    );
+
+    const microformParams =
+      '&Form=30&isbn=1234';
+    const href = baseUrl + microformParams + moreParams;
+
+    await testLink(
+      getByRole,
+      container,
+      'Copy unavailable, request via Interlibrary Loan',
       href
     );
   });

--- a/spec/javascript/availability/components/ill_link.jsx.spec.js
+++ b/spec/javascript/availability/components/ill_link.jsx.spec.js
@@ -107,8 +107,7 @@ describe('when all fields are present', () => {
       />
     );
 
-    const microformParams =
-      '&Form=30&isbn=1234';
+    const microformParams = '&Form=30&isbn=1234';
     const href = baseUrl + microformParams + moreParams;
 
     await testLink(


### PR DESCRIPTION
Exclude holdings that have ILL Locations from having microfilm scan links.  Instead, indicate the copy is unavailable and link to ILL.

The example in #1079 now looks like this: 
![Screen Shot 2022-12-01 at 12 39 48 PM](https://user-images.githubusercontent.com/32677188/205122461-f3ad2130-c034-4997-a4ad-7a542d3de086.png)

closes #1079 