### PR TITLE
ensures that rails is pid 1

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -25,4 +25,4 @@ fi
 
 echo "starting rails"
 
-bundle exec rails s -b '0.0.0.0'
+exec bundle exec rails s -b '0.0.0.0'


### PR DESCRIPTION
This is an interesting read, ensuring that our startup scripts start our daemons as pid 1 have plenty of benefits
https://about.gitlab.com/blog/2022/05/17/how-we-removed-all-502-errors-by-caring-about-pid-1-in-kubernetes/
