### PR TITLE
Sort by purchase date

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -488,7 +488,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'score desc, pub_date_itsi desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_itsi desc, title_sort asc', label: 'year'
     config.add_sort_field 'title_sort asc, pub_date_itsi desc', label: 'title'
-    config.add_sort_field 'purchase-date', sort: 'id_sort desc', label: 'purchase date' #try zero padding, adds zeros to the front to make them all the same length?
+    config.add_sort_field 'purchase-date', sort: 'id_sort desc', label: 'purchase date' 
 
     # Configuration for autocomplete suggestor
     # Disable until https://github.com/projectblacklight/blacklight/issues/1972 resolved

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -488,6 +488,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'score desc, pub_date_itsi desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_itsi desc, title_sort asc', label: 'year'
     config.add_sort_field 'title_sort asc, pub_date_itsi desc', label: 'title'
+    config.add_sort_field 'purchase-date', sort: 'id_sort desc', label: 'purchase date' #try zero padding, adds zeros to the front to make them all the same length?
 
     # Configuration for autocomplete suggestor
     # Disable until https://github.com/projectblacklight/blacklight/issues/1972 resolved

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -488,7 +488,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'score desc, pub_date_itsi desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_itsi desc, title_sort asc', label: 'year'
     config.add_sort_field 'title_sort asc, pub_date_itsi desc', label: 'title'
-    config.add_sort_field 'purchase-date', sort: 'id_sort desc', label: 'purchase date' 
+    config.add_sort_field 'purchase-date', sort: 'id_sort desc', label: 'purchase date'
 
     # Configuration for autocomplete suggestor
     # Disable until https://github.com/projectblacklight/blacklight/issues/1972 resolved

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -240,6 +240,7 @@
 
     <!-- Sorts -->
     <field name="title_sort"          type="string" docValues="true" indexed="true" stored="false" multiValued="true" />
+    <field name="id_sort"             type="int" docValues="true" indexed="true" stored="false" multiValued="true" />
   </fields>
 
 
@@ -257,6 +258,7 @@
   <copyField source="*_tesim" dest="suggest"/>
   <copyField source="*_ssim" dest="suggest"/>
   <copyField source="*_si" dest="suggest"/>
+  <copyField source="id" dest="id_sort" />
 
   <!-- unstemmed fields -->
   <copyField source="title_tsim" dest="title_unstem_search"/>

--- a/spec/features/sort_by_spec.rb
+++ b/spec/features/sort_by_spec.rb
@@ -6,11 +6,59 @@ RSpec.describe 'Sort by', type: :feature do
   describe 'search result page', js: true do
     before do
       visit '/?search_field=all_fields&q=history'
+      click_on 'Sort by relevance'
+    end
+
+    context 'when sort by relevance is selected' do
+      before do
+        click_on 'relevance'
+      end
+
+      it 'displays the correct headers' do
+        expect(page).to have_content 'Sort by relevance'
+      end
+
+      it 'displays results content' do
+        within '#documents' do
+          expect(page).to have_selector 'article[data-document-id="11160284"]'
+        end
+      end
+    end
+
+    context 'when sort by year is selected' do
+      before do
+        click_on 'year'
+      end
+
+      it 'displays the correct headers' do
+        expect(page).to have_content 'Sort by year'
+      end
+
+      it 'displays results content' do
+        within '#documents' do
+          expect(page).to have_selector 'article[data-document-id="21601671"]'
+        end
+      end
+    end
+
+    context 'when sort by title is selected' do
+      before do
+        click_on 'title'
+      end
+
+      it 'displays the correct headers' do
+        expect(page).to have_content 'Sort by title'
+      end
+
+      it 'displays results content' do
+        within '#documents' do
+          expect(page).to have_selector 'article[data-document-id="1293861"]'
+        end
+      end
     end
 
     context 'when sort by purchase date is selected' do
       before do
-        click_on 'Sort by relevance'
         click_on 'purchase date'
       end
 
@@ -20,7 +68,7 @@ RSpec.describe 'Sort by', type: :feature do
 
       it 'displays results content' do
         within '#documents' do
-          expect(page).to have_selector 'article[data-document-id="31805621"]'
+          expect(page).to have_selector 'article[data-document-id="27422489"]'
           expect(page).not_to have_selector 'article[data-document-id="11160284"]'
         end
       end

--- a/spec/features/sort_by_spec.rb
+++ b/spec/features/sort_by_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Sort by', type: :feature do
+  describe 'search result page', js: true do
+    before do
+      visit '/?search_field=all_fields&q=history'
+    end
+
+    context 'when sort by purchase date is selected' do
+      before do
+        click_on 'Sort by relevance'
+        click_on 'purchase date'
+      end
+
+      it 'displays the correct headers' do
+        expect(page).to have_content 'Sort by purchase date'
+      end
+
+      it 'displays results content' do
+        within '#documents' do
+          expect(page).to have_selector 'article[data-document-id="31805621"]'
+          expect(page).not_to have_selector 'article[data-document-id="11160284"]'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1025 

Sorts results from newest to oldest using catkey as a way to determine purchase date. The Solr schema was adjusted, so we will need to reindex.