### PR TITLE
make db connection pool configurable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ production:
   adapter: mysql2
   encoding: utf8
   host: <%= ENV.fetch("MYSQL_HOST", Settings.mysql.host ) %>
-  pool: 5
+  pool: <%= Settings.mysql.connection_pool %>
   username: <%= ENV.fetch("MYSQL_USER", Settings.mysql.user ) %>
   password: <%= ENV.fetch("MYSQL_PASSWORD", Settings.mysql.password ) %>
   timeout: 5000

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@ hold_button_url: https://myaccount.qa.k8s.libraries.psu.edu/holds/new?catkey=
 sirsi_url: https://cat.libraries.psu.edu:28443/symwsbc/rest/standard/lookupTitleInfo?clientID=PSUCATALOG&includeAvailabilityInfo=true&includeItemInfo=true
 matomo_id: 10
 mysql:
+  connection_pool: 10
   host: 127.0.0.1
 datadog:
   enabled: false


### PR DESCRIPTION
```
irb(main):003:0> Rails.application.config_for(:database)
=>
{:adapter=>"mysql2",
 :encoding=>"utf8",
 :host=>"catalog-connpool-mysql-master",
 :pool=>10,
 :username=>"blackcat",
```

we are seeing a rise of connection pool errors in prod, they are happening mostly to bots, but discovered we can't change this on the fly so this PR makes the connection pool configurable. 

we might want to see if we can prevent bot users from interacting with the database. I'm not sure what operations are even happening, we might need to increase logging for db statements to see? 


