### PR TITLE
reverting ILL changes

### DIFF
--- a/app/javascript/availability/components/special_request_link.jsx
+++ b/app/javascript/availability/components/special_request_link.jsx
@@ -20,7 +20,7 @@ const SpecialRequestLink = ({ holding, locationText }) => {
   const createUrl = () => {
     let linkUrl = locationText
       ? 'https://aeon.libraries.psu.edu/RemoteAuth/aeon.dll'
-      : 'https://psu.illiad.oclc.org/illiad/';
+      : 'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/';
     fetchJson(`/catalog/${catkey}/raw.json`)
       .then((data) => {
         if (Object.keys(data).length > 0) {

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe 'Availability', :vcr, type: :feature do
         within 'div[data-library="UP-ANNEX"]' do
           expect(page).to have_link(
             'Request Scan - Penn State Users',
-            href: 'https://psu.illiad.oclc.org/illiad/upm/illiad.dll/' \
+            href: 'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/upm/illiad.dll/' \
                   'OpenURL?Action=10&Form=20&Genre=GenericRequestThesisDigitization&title=Ecology' \
                   '%20of%20the%20wild-trapped%20and%20transplanted%20ring-necked%20pheasant%20near' \
                   '%20Centre%20Hall%2C%20Pennsylvania&callno=Thesis%201968mMyers%2CJE&rfr_id=info' \
@@ -437,7 +437,7 @@ RSpec.describe 'Availability', :vcr, type: :feature do
         within 'div[data-library="HARRISBURG"]' do
           expect(page).to have_link(
             'Copy unavailable, request via Interlibrary Loan',
-            href: 'https://psu.illiad.oclc.org/illiad/upm/illiad.dll/' \
+            href: 'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/upm/illiad.dll/' \
                   'OpenURL?Action=10&Form=30&isbn=9781599901091' \
                   '&title=Sun%20and%20moon%2C%20ice%20and%20snow&callno=PZ8.G3295Su%202008&rfr_id=' \
                   'info%3Asid%2Fcatalog.libraries.psu.edu&aulast=George%2C%20Jessica%20Day%2C%201976' \

--- a/spec/javascript/availability/components/special_request_link.jsx.spec.js
+++ b/spec/javascript/availability/components/special_request_link.jsx.spec.js
@@ -147,7 +147,8 @@ describe('when locationText is sent to SpecialRequestLink', () => {
 
 describe('when locationText is not sent to SpecialRequestLink', () => {
   const baseUrl =
-    'https://psu.illiad.oclc.org/illiad/upm/illiad.dll/OpenURL?Action=10';
+    'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/upm/illiad.dll/' +
+    'OpenURL?Action=10';
   const holdingData = { locationID: 'BINDERY', callNumber: '123' };
 
   const testLink = async (getByRole, container, label, href) => {
@@ -384,7 +385,7 @@ describe('when locationText is not sent to SpecialRequestLink', () => {
       getByRole,
       container,
       'Use ILLiad to request this item',
-      'https://psu.illiad.oclc.org/illiad/'
+      'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/'
     );
 
     expect(getByRole('link')).toHaveAttribute('target', '_blank');
@@ -401,7 +402,7 @@ describe('when locationText is not sent to SpecialRequestLink', () => {
       getByRole,
       container,
       'Use ILLiad to request this item',
-      'https://psu.illiad.oclc.org/illiad/'
+      'https://psu-illiad-oclc-org.ezaccess.libraries.psu.edu/illiad/'
     );
 
     expect(getByRole('link')).toHaveAttribute('target', '_blank');


### PR DESCRIPTION
We need to revert ILL changes since the ILLiad switch did not roll out due to EZProxy issues. OCLC and PSU will be troubleshooting it and once it is resolved, we will do these changes then. 