### PR TITLE
fix redis deprication

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -64,9 +64,9 @@ class Search
   end
 
   def save
-    redis.multi do
-      redis.set(id, @query_params.to_json)
-      redis.expire(id, ttl)
+    redis.multi do |pipeline|
+      pipeline.set(id, @query_params.to_json)
+      pipeline.expire(id, ttl)
     end
 
     self

--- a/app/models/search_history.rb
+++ b/app/models/search_history.rb
@@ -47,10 +47,10 @@ class SearchHistory
   def add(search)
     key = search.try(:id) || search
 
-    redis.multi do
-      redis.lpush(id, key)
-      redis.ltrim(id, 0, (limit - 1))
-      redis.expire(id, ttl)
+    redis.multi do |pipeline|
+      pipeline.lpush(id, key)
+      pipeline.ltrim(id, 0, (limit - 1))
+      pipeline.expire(id, ttl)
     end
 
     reload


### PR DESCRIPTION
Fixes redis pipelining in preparation for redis 5. 

We didn't update redis at this time, because it's not compatible with the version of datadog that we are using; and we can't update datadog because of our MonkeyPatching on Datadog. 