### PR TITLE
"Include all online results" button for campus facet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ config/master.key
 # Ignore bundler config.
 /.bundle
 
+# Ignore vendor/bundle files
+vendor/bundle/**/*
+
 # Ignore the SQLite database.
 /blackcat_dev
 /blackcat_test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,7 @@ RSpec/RepeatedExampleGroupBody:
 RSpec/MessageSpies:
   Exclude:
   - 'spec/controllers/catalog_controller_spec.rb'
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+  - 'spec/models/search_builder_spec.rb'

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -60,4 +60,22 @@ module FacetsHelper
     default_component = facet_config.pivot ? Blacklight::FacetItemPivotComponent : PsulFacetItemComponent
     facet_config.fetch(:item_component, default_component)
   end
+
+  def campus_facet_all_online_links
+    if params['f'].keys == ['campus_facet']
+      if params[:add_all_online].present?
+        link_to(
+          'Remove online results',
+          "?#{params.except(:controller, :action, :add_all_online).to_query}",
+          class: 'btn btn-outline-secondary btn-sm mt-2'
+        )
+      else
+        link_to(
+          'Include all online results',
+          "?#{params.except(:controller, :action, :add_all_online).to_query}&add_all_online=true",
+          class: 'btn btn-outline-primary btn-sm mt-2'
+        )
+      end
+    end
+  end
 end

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -62,8 +62,8 @@ module FacetsHelper
   end
 
   def campus_facet_all_online_links
-    if params['f']&.keys == ['campus_facet']
-      if params['add_all_online'].present?
+    if params[:f]&.keys == ['campus_facet']
+      if params[:add_all_online].present?
         link_to(
           'Remove online results',
           "?#{params.except(:controller, :action, :add_all_online).to_query}",

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -62,7 +62,7 @@ module FacetsHelper
   end
 
   def campus_facet_all_online_links
-    if params['f'].keys == ['campus_facet']
+    if params['f']&.keys == ['campus_facet']
       if params[:add_all_online].present?
         link_to(
           'Remove online results',

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -63,7 +63,7 @@ module FacetsHelper
 
   def campus_facet_all_online_links
     if params['f']&.keys == ['campus_facet']
-      if params[:add_all_online].present?
+      if params['add_all_online'].present?
         link_to(
           'Remove online results',
           "?#{params.except(:controller, :action, :add_all_online).to_query}",

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,7 +4,17 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
-  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr,
+                                   :add_all_online_to_query]
+
+  def add_all_online_to_query(solr_parameters)
+    if campus_facet_all_online_query?(solr_parameters)
+      solr_parameters[:fq] ||= []
+
+      solr_parameters[:fq].first.prepend('access_facet:Online OR ')
+      solr_parameters[:fq][0] = solr_parameters[:fq].first.gsub('}', " v='") << "'}"
+    end
+  end
 
   ##
   # @example Adding a new step to the processor chain
@@ -13,4 +23,12 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   def add_custom_data_to_query(solr_parameters)
   #     solr_parameters[:custom] = blacklight_params[:user_value]
   #   end
+
+  private
+
+    def campus_facet_all_online_query?(solr_parameters)
+      blacklight_params['add_all_online'] == 'true' &&
+        solr_parameters['fq']&.count == 1 &&
+        solr_parameters['fq']&.first&.include?('tag=campus_facet_single')
+    end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -28,7 +28,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     def campus_facet_all_online_query?(solr_parameters)
       blacklight_params['add_all_online'] == 'true' &&
-        solr_parameters['fq']&.count == 1 &&
-        solr_parameters['fq']&.first&.include?('tag=campus_facet_single')
+        solr_parameters[:fq]&.count == 1 &&
+        solr_parameters[:fq]&.first&.include?('tag=campus_facet_single')
     end
 end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -19,6 +19,8 @@
 
 <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
 
+<%= campus_facet_all_online_links %>
+
 <%- if @response.empty? %>
   <%= render 'zero_results' %>
 <%- elsif render_grouped_response? %>

--- a/spec/features/campus_facet_all_online_spec.rb
+++ b/spec/features/campus_facet_all_online_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Campus Facet Add All Online', type: :feature do
   describe 'Adding and removing online items to campus facet filter', js: true do
     it 'adds online items' do
-      # This test is dependent on there being 21 Behrend items and 134 
+      # This test is dependent on there being 21 Behrend items and 134
       # Online items. Adding records to the fixtures could break this.
       visit '/?f[campus_facet][]=Penn+State+Behrend'
       expect(page).to have_content ' 1 - 10 of 21 '

--- a/spec/features/campus_facet_all_online_spec.rb
+++ b/spec/features/campus_facet_all_online_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Campus Facet Add All Online', type: :feature do
+  describe 'Adding and removing online items to campus facet filter', js: true do
+    it 'adds online items' do
+      visit '/?f[campus_facet][]=Penn+State+Behrend'
+      expect(page).to have_content ' 1 - 10 of 21 '
+      click_on 'Include all online results'
+      expect(page).to have_content ' 1 - 10 of 155 '
+      click_on 'Remove online results'
+      expect(page).to have_content ' 1 - 10 of 21 '
+    end
+  end
+end

--- a/spec/features/campus_facet_all_online_spec.rb
+++ b/spec/features/campus_facet_all_online_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Campus Facet Add All Online', type: :feature do
   describe 'Adding and removing online items to campus facet filter', js: true do
     it 'adds online items' do
+      # This test is dependent on there being 21 Behrend items and 134 
+      # Online items. Adding records to the fixtures could break this.
       visit '/?f[campus_facet][]=Penn+State+Behrend'
       expect(page).to have_content ' 1 - 10 of 21 '
       click_on 'Include all online results'

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -106,4 +106,54 @@ RSpec.describe FacetsHelper do
       end
     end
   end
+
+  describe 'campus_facet_all_online_links?' do
+    context "when params['f'] is nil" do
+      before do
+        allow(helper).to receive_messages(params: {})
+      end
+
+      it 'returns nothing' do
+        expect(helper.campus_facet_all_online_links).to be_nil
+      end
+    end
+
+    context "when params['f'] is not filtering on only campus_facet" do
+      before do
+        allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'],
+                                                             'format' => ['Book'] } })
+      end
+
+      it 'returns nothing' do
+        expect(helper.campus_facet_all_online_links).to be_nil
+      end
+    end
+
+    context "when params['f'] is filtering on only campus_facet" do
+      context "when params[:add_all_online] is not 'true'" do
+        before do
+          allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'] } })
+        end
+
+        it 'returns a link to "Include all online results"' do
+          expect(helper.campus_facet_all_online_links).to eq '<a class="btn btn-outline-primary btn-sm mt-2" href="' \
+                                                             '?f%5Bcampus_facet%5D%5B%5D=Penn+State+Great+Valley&am' \
+                                                             'p;add_all_online=true">Include all online results</a>'
+        end
+      end
+
+      context "when params[:add_all_online] is 'true'" do
+        before do
+          allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'] },
+                                                      'add_all_online' => 'true' })
+        end
+
+        it 'returns a link to "Remove online results"' do
+          expect(helper.campus_facet_all_online_links).to eq '<a class="btn btn-outline-secondary btn-sm mt-2" href' \
+                                                             '="?add_all_online=true&amp;f%5Bcampus_facet%5D%5B%5D=' \
+                                                             'Penn+State+Great+Valley">Remove online results</a>'
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe FacetsHelper do
     end
   end
 
-  describe 'campus_facet_all_online_links?' do
+  describe 'campus_facet_all_online_links' do
     context 'when params[:f] is nil' do
       before do
         allow(helper).to receive_messages(params: {})

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe FacetsHelper do
   end
 
   describe 'campus_facet_all_online_links?' do
-    context "when params['f'] is nil" do
+    context 'when params[:f] is nil' do
       before do
         allow(helper).to receive_messages(params: {})
       end
@@ -118,10 +118,10 @@ RSpec.describe FacetsHelper do
       end
     end
 
-    context "when params['f'] is not filtering on only campus_facet" do
+    context 'when params[:f] is not filtering on only campus_facet' do
       before do
-        allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'],
-                                                             'format' => ['Book'] } })
+        allow(helper).to receive_messages(params: { f: { 'campus_facet' => ['Penn State Great Valley'],
+                                                         'format' => ['Book'] } })
       end
 
       it 'returns nothing' do
@@ -129,10 +129,10 @@ RSpec.describe FacetsHelper do
       end
     end
 
-    context "when params['f'] is filtering on only campus_facet" do
+    context 'when params[:f] is filtering on only campus_facet' do
       context "when params[:add_all_online] is not 'true'" do
         before do
-          allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'] } })
+          allow(helper).to receive_messages(params: { f: { 'campus_facet' => ['Penn State Great Valley'] } })
         end
 
         it 'returns a link to "Include all online results"' do
@@ -144,14 +144,14 @@ RSpec.describe FacetsHelper do
 
       context "when params[:add_all_online] is 'true'" do
         before do
-          allow(helper).to receive_messages(params: { 'f' => { 'campus_facet' => ['Penn State Great Valley'] },
-                                                      'add_all_online' => 'true' })
+          allow(helper).to receive_messages(params: { f: { 'campus_facet' => ['Penn State Great Valley'] },
+                                                      add_all_online: 'true' })
         end
 
         it 'returns a link to "Remove online results"' do
-          expect(helper.campus_facet_all_online_links).to eq '<a class="btn btn-outline-secondary btn-sm mt-2" href' \
-                                                             '="?add_all_online=true&amp;f%5Bcampus_facet%5D%5B%5D=' \
-                                                             'Penn+State+Great+Valley">Remove online results</a>'
+          expect(helper.campus_facet_all_online_links).to eq '<a class="btn btn-outline-secondary btn-sm mt-2" hre' \
+                                                             'f="?f%5Bcampus_facet%5D%5B%5D=Penn+State+Great+Valley' \
+                                                             '">Remove online results</a>'
         end
       end
     end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe SearchBuilder, type: :model do
+  describe '#add_all_online_to_query' do
+    let(:scope) do
+      struct = Struct.new(:blacklight_config)
+      struct.new(Blacklight::Configuration.new)
+    end
+
+    context "when blacklight_params['add_all_online'] is not present" do
+      let(:blacklight_params) { {} }
+      let(:solr_parameters) { { fq: ['{!term f=campus_facet tag=campus_facet_single}'] } }
+
+      it 'returns nil' do
+        expect(described_class.new(scope)
+          .with(blacklight_params)
+          .add_all_online_to_query(solr_parameters))
+          .to be_nil
+      end
+    end
+
+    context "when blacklight_params['add_all_online'] is 'true'" do
+      let(:blacklight_params) { { 'add_all_online' => 'true' } }
+      let(:solr_parameters) { { fq: ['{!term f=campus_facet tag=campus_facet_single}Test Campus'] } }
+
+      it 'returns the campus facet OR all online query' do
+        expect(described_class.new(scope)
+          .with(blacklight_params)
+          .add_all_online_to_query(solr_parameters))
+          .to eq "access_facet:Online OR {!term f=campus_facet tag=campus_facet_single v='Test Campus'}"
+      end
+
+      context "when there's more than one filter query in the solr parameters" do
+        before do
+          solr_parameters[:fq] << '{!term f=format}Book'
+        end
+
+        it 'returns nil' do
+          expect(described_class.new(scope)
+            .with(blacklight_params)
+            .add_all_online_to_query(solr_parameters))
+            .to be_nil
+        end
+      end
+
+      context 'when the filter query is not campus_facet_single' do
+        before do
+          solr_parameters[:fq] = ['{!term f=format}Book']
+        end
+
+        it 'returns nil' do
+          expect(described_class.new(scope)
+            .with(blacklight_params)
+            .add_all_online_to_query(solr_parameters))
+            .to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The include button 👇 
![Screenshot 2023-04-17 at 4 31 56 PM](https://user-images.githubusercontent.com/32677188/232603575-421d819f-f6a5-40d2-85f8-5f3d3cb00fe2.png)

And the remove button 👇 
![Screenshot 2023-04-17 at 4 33 17 PM](https://user-images.githubusercontent.com/32677188/232603957-ff983bb9-4f3e-49ca-903b-0f1e2dcd9fc0.png)

There's no logic to remove the 'add_all_online' query parameter in the URL after clicking the include button when the user leaves the single campus facet search.  However, there is logic to ignore this parameter when the user is not in a single campus facet search.  Therefore, this should not cause any confusion or issues unless the users are very picky about URLs.

closes #529 
