### PR TITLE
Refactor IIIF manifest URL checking and tweak error handling behavior

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -65,10 +65,6 @@ class CatalogController < ApplicationController
     return redirect_to action: 'show', id: params[:id].chop if trailing_punctuation?
 
     super
-
-    if @document[:iiif_manifest_ssim].present?
-      @iiif_manifest = follow_redirects(@document[:iiif_manifest_ssim].first)
-    end
   end
 
   def ris
@@ -542,23 +538,5 @@ class CatalogController < ApplicationController
     # elsewhere.
     def searches_from_history
       session[:history] ||= SearchHistory.find_or_initialize(session.id).search_ids
-    end
-
-    def follow_redirects(url)
-      host = URI.parse(url).host
-
-      # Skip any further redirect business if we already know that we're going to get a
-      # response with good CORS headers.
-      return url if ['cdm17287.contentdm.oclc.org', 'digital.libraries.psu.edu'].include?(host)
-
-      r = Faraday.head(url)
-      case r.status
-      when 301, 302
-        follow_redirects(r.headers[:location])
-      when 200
-        url
-      end
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError
-      nil
     end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -57,6 +57,10 @@ class SolrDocument
 
       r = Faraday.head(url)
 
+      # Allow the IIIF viewer to handle any further redirects on the front end as long as
+      # we've arrived at a response that allows CORS.
+      return url if r.headers['access-control-allow-origin'] == '*'
+
       case r.status
       when 301, 302
         follow_redirects(r.headers[:location])

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -17,11 +17,11 @@
 
   </div>
 
-  <% if @iiif_manifest.present? %>
+  <% if @document.iiif_manifest_url.present? %>
     <h4>Digitized Materials</h4>
     <div class="row document-metadata metadata-primary py-4">
       <div class="col">
-        <div id="iiif-viewer" class="iiif-viewer" data-manifest="<%= @iiif_manifest %>"></div>
+        <div id="iiif-viewer" class="iiif-viewer" data-manifest="<%= @document.iiif_manifest_url %>"></div>
       </div>
     </div>
   <% end %>

--- a/spec/features/iiif_viewer_spec.rb
+++ b/spec/features/iiif_viewer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'viewing a record', js: true, vcr: { record: :new_episodes } do
   end
 
   context 'when the record has an IIIF manifest URL that returns a 500 error' do
-    let(:r) { instance_double Faraday::Response, status: 500 }
+    let(:r) { instance_double Faraday::Response, status: 500, headers: {} }
 
     before do
       allow(Faraday).to receive(:head)
@@ -42,9 +42,10 @@ RSpec.describe 'viewing a record', js: true, vcr: { record: :new_episodes } do
         .and_return r
     end
 
-    it 'does not render the Mirador viewer' do
+    it 'renders the Mirador viewer' do
       visit '/catalog/1267921'
-      expect(page).not_to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'main[class="Connect(WithPlugins(WorkspaceArea))-viewer-1 mirador-viewer"]'
     end
   end
 
@@ -55,9 +56,10 @@ RSpec.describe 'viewing a record', js: true, vcr: { record: :new_episodes } do
         .and_raise Faraday::ConnectionFailed.new(nil)
     end
 
-    it 'does not render the Mirador viewer' do
+    it 'renders the Mirador viewer' do
       visit '/catalog/1267921'
-      expect(page).not_to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'main[class="Connect(WithPlugins(WorkspaceArea))-viewer-1 mirador-viewer"]'
     end
   end
 
@@ -68,9 +70,10 @@ RSpec.describe 'viewing a record', js: true, vcr: { record: :new_episodes } do
         .and_raise Faraday::TimeoutError
     end
 
-    it 'does not render the Mirador viewer' do
+    it 'renders the Mirador viewer' do
       visit '/catalog/1267921'
-      expect(page).not_to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'div[id="iiif-viewer"]'
+      expect(page).to have_selector 'main[class="Connect(WithPlugins(WorkspaceArea))-viewer-1 mirador-viewer"]'
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/viewing_a_record/when_a_failure_occurs_while_trying_to_connect_to_the_record_s_IIIF_manifest_URL/renders_the_Mirador_viewer.yml
+++ b/spec/fixtures/vcr_cassettes/viewing_a_record/when_a_failure_occurs_while_trying_to_connect_to_the_record_s_IIIF_manifest_URL/renders_the_Mirador_viewer.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cat.libraries.psu.edu:28443/symwsbc/rest/standard/lookupTitleInfo?clientID=PSUCATALOG&includeAvailabilityInfo=true&includeBoundTogether=true&includeItemInfo=true&titleID=1267921
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - cat.libraries.psu.edu:28443
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 10 May 2023 19:28:38 GMT
+      Server:
+      - SirsiDynix IlsWS
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><LookupTitleInfoResponse
+        xmlns="http://schemas.sirsidynix.com/symws/standard"><TitleInfo><titleID>1267921</titleID><TitleAvailabilityInfo><totalCopiesAvailable>1</totalCopiesAvailable><libraryWithAvailableCopies>Pattee
+        Library and Paterno Library Stacks (UP)</libraryWithAvailableCopies><totalResvCopiesAvailable>0</totalResvCopiesAvailable><locationOfFirstAvailableItem>PATTEE-2A</locationOfFirstAvailableItem><holdable>true</holdable><bookable>false</bookable></TitleAvailabilityInfo><CallInfo><libraryID>UP-PAT</libraryID><classificationID>LCPER</classificationID><callNumber>PN851.C52
+        v.1-3 no.1 1987-89</callNumber><numberOfCopies>1</numberOfCopies><ItemInfo><itemID>000071202587</itemID><itemTypeID>PERIODICAL</itemTypeID><currentLocationID>PATTEE-2A</currentLocationID><homeLocationID>PATTEE-2A</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><numberOfBoundwithLinks>0</numberOfBoundwithLinks></TitleInfo></LookupTitleInfoResponse>
+  recorded_at: Wed, 10 May 2023 19:28:36 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_ARK_URL_that_redirects_to_the_IIIF_manifest/renders_the_Mirador_viewer.yml
+++ b/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_ARK_URL_that_redirects_to_the_IIIF_manifest/renders_the_Mirador_viewer.yml
@@ -312,4 +312,38 @@ http_interactions:
       encoding: ASCII-8BIT
       string: var _GBSBookInfo = {};
   recorded_at: Fri, 05 May 2023 19:56:23 GMT
+- request:
+    method: head
+    uri: https://arks.libraries.psu.edu/ark:/42409/ii34w27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Wed, 10 May 2023 19:15:24 GMT
+      Server:
+      - Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k
+      Strict-Transport-Security:
+      - max-age=63072000
+      Access-Control-Allow-Origin:
+      - "*"
+      Location:
+      - https://n2t.net//ark:/42409/ii34w27
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 10 May 2023 19:15:22 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL_that_returns_a_500_error/renders_the_Mirador_viewer.yml
+++ b/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL_that_returns_a_500_error/renders_the_Mirador_viewer.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://books.google.com/books?bibkeys=LCCN:sn%2088016767&jscmd=viewapi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - books.google.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 May 2023 19:28:35 GMT
+      Expires:
+      - Wed, 10 May 2023 19:28:35 GMT
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      - policyref="http://www.google.com/googlebooks/p3p.xml", CP="DSP NON ADM DEV
+        OUR BUS NAV COM INT STA"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=604800
+      Content-Type:
+      - application/javascript; charset=ISO-8859-1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Disposition:
+      - attachment; filename="f.txt"
+      Server:
+      - OFE/0.1
+      Set-Cookie:
+      - NID=511=k5Y4KyR0tiEgB1PqUa6YW8mJeYFzQbwYO5O_TG1hrPrVjQQk-AQ0eE2kdhA8OHogSq7Dryj2Qhf-R6dedwAZfv53MOS05QvvnXOKEagCq1XEgPEVB9ocFtVwyqFkNLt1yx2eSiWL3yaZXa2LeovrSU2wfuea92u6yHDzK3B05_Q;
+        expires=Thu, 09-Nov-2023 19:28:35 GMT; path=/; domain=.google.com; HttpOnly
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: var _GBSBookInfo = {};
+  recorded_at: Wed, 10 May 2023 19:28:34 GMT
+- request:
+    method: get
+    uri: https://cat.libraries.psu.edu:28443/symwsbc/rest/standard/lookupTitleInfo?clientID=PSUCATALOG&includeAvailabilityInfo=true&includeBoundTogether=true&includeItemInfo=true&titleID=1267921
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - cat.libraries.psu.edu:28443
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 10 May 2023 19:28:35 GMT
+      Server:
+      - SirsiDynix IlsWS
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><LookupTitleInfoResponse
+        xmlns="http://schemas.sirsidynix.com/symws/standard"><TitleInfo><titleID>1267921</titleID><TitleAvailabilityInfo><totalCopiesAvailable>1</totalCopiesAvailable><libraryWithAvailableCopies>Pattee
+        Library and Paterno Library Stacks (UP)</libraryWithAvailableCopies><totalResvCopiesAvailable>0</totalResvCopiesAvailable><locationOfFirstAvailableItem>PATTEE-2A</locationOfFirstAvailableItem><holdable>true</holdable><bookable>false</bookable></TitleAvailabilityInfo><CallInfo><libraryID>UP-PAT</libraryID><classificationID>LCPER</classificationID><callNumber>PN851.C52
+        v.1-3 no.1 1987-89</callNumber><numberOfCopies>1</numberOfCopies><ItemInfo><itemID>000071202587</itemID><itemTypeID>PERIODICAL</itemTypeID><currentLocationID>PATTEE-2A</currentLocationID><homeLocationID>PATTEE-2A</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><numberOfBoundwithLinks>0</numberOfBoundwithLinks></TitleInfo></LookupTitleInfoResponse>
+  recorded_at: Wed, 10 May 2023 19:28:34 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL_that_returns_a_500_error/renders_the_Mirador_viewer_with_an_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL_that_returns_a_500_error/renders_the_Mirador_viewer_with_an_error_message.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cat.libraries.psu.edu:28443/symwsbc/rest/standard/lookupTitleInfo?clientID=PSUCATALOG&includeAvailabilityInfo=true&includeBoundTogether=true&includeItemInfo=true&titleID=1267921
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - cat.libraries.psu.edu:28443
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 10 May 2023 19:24:57 GMT
+      Server:
+      - SirsiDynix IlsWS
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><LookupTitleInfoResponse
+        xmlns="http://schemas.sirsidynix.com/symws/standard"><TitleInfo><titleID>1267921</titleID><TitleAvailabilityInfo><totalCopiesAvailable>1</totalCopiesAvailable><libraryWithAvailableCopies>Pattee
+        Library and Paterno Library Stacks (UP)</libraryWithAvailableCopies><totalResvCopiesAvailable>0</totalResvCopiesAvailable><locationOfFirstAvailableItem>PATTEE-2A</locationOfFirstAvailableItem><holdable>true</holdable><bookable>false</bookable></TitleAvailabilityInfo><CallInfo><libraryID>UP-PAT</libraryID><classificationID>LCPER</classificationID><callNumber>PN851.C52
+        v.1-3 no.1 1987-89</callNumber><numberOfCopies>1</numberOfCopies><ItemInfo><itemID>000071202587</itemID><itemTypeID>PERIODICAL</itemTypeID><currentLocationID>PATTEE-2A</currentLocationID><homeLocationID>PATTEE-2A</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><numberOfBoundwithLinks>0</numberOfBoundwithLinks></TitleInfo></LookupTitleInfoResponse>
+  recorded_at: Wed, 10 May 2023 19:24:55 GMT
+- request:
+    method: get
+    uri: https://books.google.com/books?bibkeys=LCCN:sn%2088016767&jscmd=viewapi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - books.google.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 May 2023 19:24:57 GMT
+      Expires:
+      - Wed, 10 May 2023 19:24:57 GMT
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      - policyref="http://www.google.com/googlebooks/p3p.xml", CP="DSP NON ADM DEV
+        OUR BUS NAV COM INT STA"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=604800
+      Content-Type:
+      - application/javascript; charset=ISO-8859-1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Disposition:
+      - attachment; filename="f.txt"
+      Server:
+      - OFE/0.1
+      Set-Cookie:
+      - NID=511=SvnkTDUhs60T6-w8x58Ch7QWvZD6v0E-5hf6nXAyDhYBc3TRACoZ5pzYjVaofWy9dXnkBbq-dfZYLxE1glD1MG1l2FNrXsheT3TdjzUy5DGevJaXCzJW3E9bwZms1hFjALtztvclYikVTeVmrj2TOBj60f_OQoFUgCZWyTPmx9c;
+        expires=Thu, 09-Nov-2023 19:24:57 GMT; path=/; domain=.google.com; HttpOnly
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: var _GBSBookInfo = {};
+  recorded_at: Wed, 10 May 2023 19:24:55 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context "when the document's iiif_manifest_ssim field contains an array containing one string that is not a valid URL" do
+    context "when the document's iiif_manifest_ssim field contains an array with a string that is not a valid URL" do
       let(:manifest) { ['not a valid URL'] }
 
       it 'returns the string' do
@@ -31,7 +31,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with host cdm17287.contentdm.oclc.org" do
+    context "when the document's iiif_manifest_ssim field contains an array with a valid Content DM URL" do
       let(:manifest) { ['https://cdm17287.contentdm.oclc.org/manifest'] }
 
       it 'returns the URL without making any HTTP requests' do
@@ -40,7 +40,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with host digital.libraries.psu.edu" do
+    context "when the document's iiif_manifest_ssim field contains an array with a valid PSU digital collections URL" do
       let(:manifest) { ['https://digital.libraries.psu.edu/manifest'] }
 
       it 'returns the URL without making any HTTP requests' do
@@ -49,7 +49,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with some other host" do
+    context "when the document's iiif_manifest_ssim field contains an array with a valid URL with some other host" do
       let(:manifest) { ['https://someotherhost.edu/manifest'] }
       let(:response1) { instance_double Faraday::Response, status: response_1_status, headers: response_1_headers }
       let(:response2) { instance_double Faraday::Response, status: response_2_status, headers: response_2_headers }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SolrDocument do
   let(:d) { described_class.new(iiif_manifest_ssim: manifest) }
   let(:manifest) { nil }
 
+  before { allow(Faraday).to receive(:head) }
+
   describe '#iiif_manifest_url' do
     context "when the document's iiif_manifest_ssim field is nil" do
       it 'returns nil' do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrDocument do
+  let(:d) { described_class.new(iiif_manifest_ssim: manifest) }
+  let(:manifest) { nil }
+
+  describe '#iiif_manifest_url' do
+    context "when the document's iiif_manifest_ssim field is nil" do
+      it 'returns nil' do
+        expect(d.iiif_manifest_url).to be_nil
+      end
+    end
+
+    context "when the document's iiif_manifest_ssim field contains an empty array" do
+      let(:manifest) { [] }
+
+      it 'returns nil' do
+        expect(d.iiif_manifest_url).to be_nil
+      end
+    end
+
+    context "when the document's iiif_manifest_ssim field contains an array containing one string that is not a valid URL" do
+      let(:manifest) { ['not a valid URL'] }
+
+      it 'returns the string' do
+        expect(d.iiif_manifest_url).to eq 'not a valid URL'
+      end
+    end
+
+    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with host cdm17287.contentdm.oclc.org" do
+      let(:manifest) { ['https://cdm17287.contentdm.oclc.org/manifest'] }
+
+      it 'returns the URL without making any HTTP requests' do
+        expect(d.iiif_manifest_url).to eq 'https://cdm17287.contentdm.oclc.org/manifest'
+        expect(Faraday).not_to have_received(:head)
+      end
+    end
+
+    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with host digital.libraries.psu.edu" do
+      let(:manifest) { ['https://digital.libraries.psu.edu/manifest'] }
+
+      it 'returns the URL without making any HTTP requests' do
+        expect(d.iiif_manifest_url).to eq 'https://digital.libraries.psu.edu/manifest'
+        expect(Faraday).not_to have_received(:head)
+      end
+    end
+
+    context "when the document's iiif_manifest_ssim field contains an array containing one valid URL with some other host" do
+      let(:manifest) { ['https://someotherhost.edu/manifest'] }
+      let(:response) { instance_double Faraday::Response }
+
+      before do
+        allow(Faraday).to receive(:head).with('https://someotherhost.edu/manifest').and_return response
+      end
+
+      context 'when a head request for the URL returns a 200 response' do
+        before { allow(response).to receive(:status).and_return 200 }
+
+        it 'returns the URL' do
+          expect(d.iiif_manifest_url).to eq 'https://someotherhost.edu/manifest'
+        end
+      end
+
+      context 'when a head request for the URL returns a 500 response' do
+        before { allow(response).to receive(:status).and_return 500 }
+
+        it 'returns the URL' do
+          expect(d.iiif_manifest_url).to eq 'https://someotherhost.edu/manifest'
+        end
+      end
+
+      context 'when a head request for the URL returns a 301 response' do
+        let(:response2) { instance_double Faraday::Response, status: 200 }
+
+        before do
+          allow(response).to receive(:status).and_return 301
+          allow(response).to receive(:headers).and_return({ location: 'https://yetanotherhost.edu/manifest' })
+          allow(Faraday).to receive(:head).with('https://yetanotherhost.edu/manifest').and_return response2
+        end
+
+        context "when a head request for the response's location returns a 200 reponse" do
+          it "returns the response's location" do
+            expect(d.iiif_manifest_url).to eq 'https://yetanotherhost.edu/manifest'
+          end
+        end
+      end
+
+      context 'when a head request for the URL returns a 302 response' do
+        let(:response2) { instance_spy Faraday::Response, status: 200 }
+
+        before do
+          allow(response).to receive(:status).and_return 302
+          allow(response).to receive(:headers).and_return({ location: 'https://yetanotherhost.edu/manifest' })
+          allow(Faraday).to receive(:head).with('https://yetanotherhost.edu/manifest').and_return response2
+        end
+
+        context "when a head request for the response's location returns a 200 reponse" do
+          it "returns the response's location" do
+            expect(d.iiif_manifest_url).to eq 'https://yetanotherhost.edu/manifest'
+          end
+        end
+      end
+
+      context 'when a head request for the URL fails to connect' do
+        before do
+          allow(Faraday).to receive(:head).with('https://someotherhost.edu/manifest').and_raise(Faraday::ConnectionFailed.new(nil))
+        end
+
+        it 'returns the URL' do
+          expect(d.iiif_manifest_url).to eq 'https://someotherhost.edu/manifest'
+        end
+      end
+
+      context 'when a head request for the URL times out' do
+        before do
+          allow(Faraday).to receive(:head).with('https://someotherhost.edu/manifest').and_raise(Faraday::TimeoutError)
+        end
+
+        it 'returns the URL' do
+          expect(d.iiif_manifest_url).to eq 'https://someotherhost.edu/manifest'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here's a light refactoring to get this behavior closer to the data and to improve the test coverage.

I also changed how we handle errors encountered during this process so that problematic URLs are passed on to Mirador, thus allowing it to render error information instead of simply not displaying the viewer at all.