### PR TITLE
ILLiad link hotfix

### DIFF
--- a/app/javascript/availability/components/location_info.jsx
+++ b/app/javascript/availability/components/location_info.jsx
@@ -17,7 +17,7 @@ const LocationInfo = ({ holding }) => {
   // AEON
   if (availability.isArchivalThesis(holding)) {
     const illiadURL =
-      'https://psu.illiad.oclc.org/illiad/upm/lending/lendinglogon.html';
+      'https://psu.illiad.oclc.org/upm2/lending/lendinglogon.html';
     const aeonLocationText = mapLocation(holding.locationID);
 
     return (

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe 'Availability', :vcr, type: :feature do
           )
           expect(page).to have_link(
             'Request Scan - Guest',
-            href: 'https://psu.illiad.oclc.org/illiad/upm/lending/lendinglogon.html'
+            href: 'https://psu.illiad.oclc.org/upm2/lending/lendinglogon.html'
           )
           expect(page).to have_link(
             'View in Special Collections',


### PR DESCRIPTION
Base url for "Request Scan - Guest" link for archival theses was changed but with recent ILLiad updates, the full url needed to be updated