### PR TITLE
Thesis Department display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -205,6 +205,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_browse_facet', show: false, limit: 0
     config.add_facet_field 'subject_facet', show: false
     config.add_facet_field 'title_sort', label: 'Title', show: false
+    config.add_facet_field 'thesis_dept_facet', show: false
 
     #
     # Facets that only appear on the home page
@@ -368,6 +369,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'references_note_ssm', label: 'Reviewed/Cited In', helper_method: :newline_format
     config.add_show_field 'dedication_ssim', label: 'Dedication', helper_method: :newline_format
     config.add_show_field 'endowment_note_display_ssm', label: 'Endowment Note', helper_method: :newline_format
+    config.add_show_field 'thesis_dept_display_ssm', label: 'Thesis Department', helper_method: :thesis_dept_links
 
     # Order not yet specified
     # config.add_show_field 'lc_callnum_display_ssm', label: 'Call number'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -275,6 +275,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'edition_display_ssm', label: 'Edition', top_field: true, if: false, helper_method: :newline_format
     config.add_show_field 'phys_desc_ssm', label: 'Physical Description', top_field: true, if: false, helper_method: :newline_format
     config.add_show_field 'addl_author_display_ssm', label: 'Additional Creators', link_to_facet: :all_authors_facet, top_field: true, if: false
+    config.add_show_field 'thesis_dept_display_ssm', label: 'Thesis Department', helper_method: :thesis_dept_links
     config.add_show_field 'series_title_display_ssm', label: 'Series', helper_method: :series_links
     config.add_show_field 'language_ssim', label: 'Language'
     config.add_show_field 'language_note_ssm', label: 'Language Note', helper_method: :newline_format
@@ -369,7 +370,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'references_note_ssm', label: 'Reviewed/Cited In', helper_method: :newline_format
     config.add_show_field 'dedication_ssim', label: 'Dedication', helper_method: :newline_format
     config.add_show_field 'endowment_note_display_ssm', label: 'Endowment Note', helper_method: :newline_format
-    config.add_show_field 'thesis_dept_display_ssm', label: 'Thesis Department', helper_method: :thesis_dept_links
 
     # Order not yet specified
     # config.add_show_field 'lc_callnum_display_ssm', label: 'Call number'

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -53,6 +53,18 @@ module CatalogHelper
     content_tag 'ul', result.join, nil, false
   end
 
+  # Makes a link to thesis_department facet
+  def thesis_dept_links(options = {})
+    result = []
+
+    options[:value].each do |thesis_dept|
+      link = link_to thesis_dept, "/?f[thesis_dept_facet][]=#{CGI.escape thesis_dept}"
+      result << content_tag('li', link, nil, false)
+    end
+
+    content_tag 'ul', result.join, nil, false
+  end
+
   # Given a list of items, displays each item on its own line
   def newline_format(options = {})
     content_tag 'span', options[:value].join('<br>'), nil, false

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -2,6 +2,7 @@
 
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
+  extend SearchLinksHelper
 
   # Makes a link to a catalog item.
   def bound_info(options = {})
@@ -29,42 +30,6 @@ module CatalogHelper
     SubjectifyService.new(options[:value]).content
   end
 
-  # Links to general subject search for other subjects
-  def other_subjectify(options = {})
-    result = []
-    options[:value].each do |subject|
-      lnk = link_to(subject,
-                    "/?search_field=subject&q=#{CGI.escape subject}",
-                    class: 'search-subject', title: "Search: #{subject}")
-      result << content_tag('li', lnk, nil, false)
-    end
-    content_tag 'ul', result.join, nil, false
-  end
-
-  # Makes a link to genre full facet
-  def genre_links(options = {})
-    result = []
-
-    options[:value].each do |genre|
-      link = link_to genre, "/?f[genre_full_facet][]=#{CGI.escape genre}"
-      result << content_tag('li', link, nil, false)
-    end
-
-    content_tag 'ul', result.join, nil, false
-  end
-
-  # Makes a link to thesis_department facet
-  def thesis_dept_links(options = {})
-    result = []
-
-    options[:value].each do |thesis_dept|
-      link = link_to thesis_dept, "/?f[thesis_dept_facet][]=#{CGI.escape thesis_dept}"
-      result << content_tag('li', link, nil, false)
-    end
-
-    content_tag 'ul', result.join, nil, false
-  end
-
   # Given a list of items, displays each item on its own line
   def newline_format(options = {})
     content_tag 'span', options[:value].join('<br>'), nil, false
@@ -83,19 +48,6 @@ module CatalogHelper
       link_to json['text'], json['url']
     end
     content_tag 'span', contents.join('<br>'), nil, false
-  end
-
-  # Links to series search for series
-  def series_links(options = {})
-    strict_titles = options[:document][:series_title_strict_tsim] || []
-    result = []
-    options[:value].zip(strict_titles).each do |series, strict_title|
-      lnk = link_to(series,
-                    "/?search_field=series&q=#{CGI.escape(strict_title || series)}",
-                    class: 'search-series', title: "Search: #{strict_title || series}")
-      result << content_tag('li', lnk, nil, false)
-    end
-    content_tag 'ul', result.join, nil, false
   end
 
   # To render format icon on search results as the default thumbnail for now
@@ -119,16 +71,6 @@ module CatalogHelper
 
   def oclc_number(document)
     document.fetch(:oclc_number_ssim, [])&.first
-  end
-
-  # Makes a link to title search
-  def title_links(options = {})
-    result = options[:value].map do |serial_title|
-      link = link_to serial_title, "/?search_field=title&q=#{CGI.escape serial_title}"
-      content_tag('li', link, nil, false)
-    end
-
-    content_tag 'ul', result.join, nil, false
   end
 
   def marc_record_details(document)

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -28,31 +28,31 @@ module SearchLinksHelper
 
   private
 
-  def generate_links(link_type, options)
-    result = []
-    options[:value].zip(strict_titles(link_type, options)).each do |item, zipped|
-      lnk = link_to(item,
-                    "/?#{search_type(link_type)}=#{CGI.escape(zipped || item)}",
-                    class: title_search_html_class(link_type), 
-                    title: search_field?(link_type) && link_type != :title ? "Search: #{zipped || item}" : nil)
-      result << content_tag('li', lnk, nil, false)
+    def generate_links(search_type, options)
+      result = []
+      options[:value].zip(strict_titles(search_type, options)).each do |item, zipped|
+        lnk = link_to(item,
+                      "/?#{search_query(search_type)}=#{CGI.escape(zipped || item)}",
+                      class: title_search_html_class(search_type),
+                      title: search_field?(search_type) && search_type != :title ? "Search: #{zipped || item}" : nil)
+        result << content_tag('li', lnk, nil, false)
+      end
+      content_tag 'ul', result.join, nil, false
     end
-    content_tag 'ul', result.join, nil, false
-  end
 
-  def search_field?(link_type)
-    [:series, :title, :subject].include?(link_type)
-  end
+    def search_field?(search_type)
+      [:series, :title, :subject].include?(search_type)
+    end
 
-  def search_type(link_type)
-    search_field?(link_type) ? "search_field=#{link_type.to_s}&q" : "f[#{link_type.to_s.concat("_facet")}][]"
-  end
+    def search_query(search_type)
+      search_field?(search_type) ? "search_field=#{search_type}&q" : "f[#{search_type.to_s.concat('_facet')}][]"
+    end
 
-  def title_search_html_class(link_type)
-    search_field?(link_type) && link_type != :title ? "search-#{link_type.to_s}" : nil
-  end
+    def title_search_html_class(search_type)
+      search_field?(search_type) && search_type != :title ? "search-#{search_type}" : nil
+    end
 
-  def strict_titles(link_type, options)
-    link_type == :series ? options[:document][:series_title_strict_tsim] || [] : []
-  end
+    def strict_titles(search_type, options)
+      search_type == :series ? options[:document][:series_title_strict_tsim] || [] : []
+    end
 end

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -48,7 +48,7 @@ module SearchLinksHelper
       search_field?(search_type) ? "search_field=#{search_type}&q" : "f[#{search_type.to_s.concat('_facet')}][]"
     end
 
-    def title_search_html_class(search_type)
+    def search_html_class(search_type)
       search_field?(search_type) && search_type != :title ? "search-#{search_type}" : nil
     end
 

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -30,7 +30,7 @@ module SearchLinksHelper
 
   def generate_links(link_type, options)
     result = []
-    options[:value].zip(strict_titles).each do |item, zipped|
+    options[:value].zip(strict_titles(link_type, options)).each do |item, zipped|
       lnk = link_to(item,
                     "/?#{search_type(link_type)}=#{CGI.escape(zipped || item)}",
                     class: title_search_html_class(link_type), 

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -23,7 +23,7 @@ module SearchLinksHelper
 
   # Makes a link to title search
   def title_links(options = {})
-    generate_links(:serial_title, options)
+    generate_links(:title, options)
   end
 
   private
@@ -34,14 +34,14 @@ module SearchLinksHelper
       lnk = link_to(item,
                     "/?#{search_type(link_type)}=#{CGI.escape(zipped || item)}",
                     class: title_search_html_class(link_type), 
-                    title: search_field?(link_type) ? "Search: #{zipped || item}" : "#{item}")
+                    title: search_field?(link_type) && link_type != :title ? "Search: #{zipped || item}" : nil)
       result << content_tag('li', lnk, nil, false)
     end
     content_tag 'ul', result.join, nil, false
   end
 
   def search_field?(link_type)
-    [:series, :serial_title, :subject].include?(link_type)
+    [:series, :title, :subject].include?(link_type)
   end
 
   def search_type(link_type)
@@ -49,7 +49,7 @@ module SearchLinksHelper
   end
 
   def title_search_html_class(link_type)
-    search_field?(link_type) ? "#{link_type.to_s}" : nil
+    search_field?(link_type) && link_type != :title ? "search-#{link_type.to_s}" : nil
   end
 
   def strict_titles(link_type, options)

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -33,7 +33,7 @@ module SearchLinksHelper
       options[:value].zip(strict_titles(search_type, options)).each do |item, zipped|
         lnk = link_to(item,
                       "/?#{search_query(search_type)}=#{CGI.escape(zipped || item)}",
-                      class: title_search_html_class(search_type),
+                      class: search_html_class(search_type),
                       title: search_field?(search_type) && search_type != :title ? "Search: #{zipped || item}" : nil)
         result << content_tag('li', lnk, nil, false)
       end

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -29,14 +29,12 @@ module SearchLinksHelper
   private
 
   def generate_links(link_type, options)
-    search_type = search_field?(link_type) ? "search_field=#{link_type.to_s}&q" : "f[#{link_type.to_s.concat("_facet")}][]"
-    title_search_html_class = search_field?(link_type) ? "#{link_type.to_s}" : nil
-    strict_titles = link_type == :series ? options[:document][:series_title_strict_tsim] || [] : []
     result = []
     options[:value].zip(strict_titles).each do |item, zipped|
       lnk = link_to(item,
-                    "/?#{search_type}=#{CGI.escape(zipped || item)}",
-                    class: title_search_html_class, title: search_field?(link_type) ? "Search: #{zipped || item}" : "#{item}")
+                    "/?#{search_type(link_type)}=#{CGI.escape(zipped || item)}",
+                    class: title_search_html_class(link_type), 
+                    title: search_field?(link_type) ? "Search: #{zipped || item}" : "#{item}")
       result << content_tag('li', lnk, nil, false)
     end
     content_tag 'ul', result.join, nil, false
@@ -44,5 +42,17 @@ module SearchLinksHelper
 
   def search_field?(link_type)
     [:series, :serial_title, :subject].include?(link_type)
+  end
+
+  def search_type(link_type)
+    search_field?(link_type) ? "search_field=#{link_type.to_s}&q" : "f[#{link_type.to_s.concat("_facet")}][]"
+  end
+
+  def title_search_html_class(link_type)
+    search_field?(link_type) ? "#{link_type.to_s}" : nil
+  end
+
+  def strict_titles(link_type, options)
+    link_type == :series ? options[:document][:series_title_strict_tsim] || [] : []
   end
 end

--- a/app/helpers/search_links_helper.rb
+++ b/app/helpers/search_links_helper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module SearchLinksHelper
+  # Makes a link to genre full facet
+  def genre_links(options = {})
+    generate_links(:genre_full, options)
+  end
+
+  # Makes a link to thesis_department facet
+  def thesis_dept_links(options = {})
+    generate_links(:thesis_dept, options)
+  end
+
+  # Links to general subject search for other subjects
+  def other_subjectify(options = {})
+    generate_links(:subject, options)
+  end
+
+  # Links to series search for series
+  def series_links(options = {})
+    generate_links(:series, options)
+  end
+
+  # Makes a link to title search
+  def title_links(options = {})
+    generate_links(:serial_title, options)
+  end
+
+  private
+
+  def generate_links(link_type, options)
+    search_type = search_field?(link_type) ? "search_field=#{link_type.to_s}&q" : "f[#{link_type.to_s.concat("_facet")}][]"
+    title_search_html_class = search_field?(link_type) ? "#{link_type.to_s}" : nil
+    strict_titles = link_type == :series ? options[:document][:series_title_strict_tsim] || [] : []
+    result = []
+    options[:value].zip(strict_titles).each do |item, zipped|
+      lnk = link_to(item,
+                    "/?#{search_type}=#{CGI.escape(zipped || item)}",
+                    class: title_search_html_class, title: search_field?(link_type) ? "Search: #{zipped || item}" : "#{item}")
+      result << content_tag('li', lnk, nil, false)
+    end
+    content_tag 'ul', result.join, nil, false
+  end
+
+  def search_field?(link_type)
+    [:series, :serial_title, :subject].include?(link_type)
+  end
+end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -54,35 +54,6 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe '#other_subjectify' do
-    let (:field_data) { ['Power Amplifiers',
-                         'Research',
-                         'Fluid Mechanics and Thermodynamics'] }
-    let (:other_subjects_doc) { { value: field_data } }
-
-    it 'provides links to general subject search based on the given other subjects' do
-      full_subject = other_subjectify other_subjects_doc
-      expect(full_subject).to eq('<ul><li><a class="search-subject" title="Search: Power Amplifiers" ' \
-                                 'href="/?search_field=subject&amp;q=Power+Amplifiers">Power Amplifiers' \
-                                 '</a></li><li><a class="search-subject" title="Search: Research" ' \
-                                 'href="/?search_field=subject&amp;q=Research">Research</a></li><li>' \
-                                 '<a class="search-subject" title="Search: Fluid Mechanics and Thermodynamics" ' \
-                                 'href="/?search_field=subject&amp;q=Fluid+Mechanics+and+Thermodynamics">' \
-                                 'Fluid Mechanics and Thermodynamics</a></li></ul>')
-    end
-  end
-
-  describe '#genre_links' do
-    let (:field_data) { ['Film adaptations', 'Feature Films'] }
-    let (:genre_doc) { { value: field_data } }
-
-    it 'assembles an unordered list of links to genre search' do
-      links = genre_links genre_doc
-      expect(links).to eq '<ul><li><a href="/?f[genre_full_facet][]=Film+adaptations">Film adaptations</a>' \
-                          '</li><li><a href="/?f[genre_full_facet][]=Feature+Films">Feature Films</a></li></ul>'
-    end
-  end
-
   describe '#newline_format' do
     let (:note_doc) { { value: ['Note 1', 'Note 2'] } }
 
@@ -116,54 +87,6 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe '#series_links' do
-    let (:series_data) { ['Lecture Notes in Electrical Engineering, 1876-1100 ; 554'] }
-    let (:series_title_strict_data) { ['Lecture Notes in Electrical Engineering'] }
-
-    context 'when there is a series value and a strict version of the series title' do
-      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
-
-      it 'assembles the link correctly' do
-        link = series_links link_doc
-        expect(link).to eql '<ul><li><a class="search-series" title="Search: Lecture Notes in ' \
-                            'Electrical Engineering" ' \
-                            'href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">' \
-                            'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
-      end
-    end
-
-    context 'when there is a series value but no strict version of the series title' do
-      let (:link_doc) { { value: series_data, document: {} } }
-
-      it 'assembles the link correctly' do
-        link = series_links link_doc
-        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering, ' \
-                      '1876-1100 ; 554" href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering' \
-                      '%2C+1876-1100+%3B+554">Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
-        expect(link).to eql link_expect
-      end
-    end
-
-    context 'when there are multiple series values and strict versions of the series title' do
-      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
-
-      before do
-        series_data << 'Series Title 2, 1999, abc123'
-        series_title_strict_data << 'Series Title 2'
-      end
-
-      it 'assembles the link correctly' do
-        link = series_links link_doc
-        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering" ' \
-                      'href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">' \
-                      'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li><li><a class="search-series" ' \
-                      'title="Search: Series Title 2" href="/?search_field=series&amp;q=Series+Title+2">Series ' \
-                      'Title 2, 1999, abc123</a></li></ul>'
-        expect(link).to eql link_expect
-      end
-    end
-  end
-
   describe '#render_thumbnail' do
     let (:document) { { format: ['Book'] } }
 
@@ -191,17 +114,6 @@ RSpec.describe CatalogHelper, type: :helper do
       oclc_num = oclc_number document
 
       expect(oclc_num).to be '123456'
-    end
-  end
-
-  describe '#title_links' do
-    let (:field_data) { ['Some Title', 'Another Title'] }
-    let (:title_doc) { { value: field_data } }
-
-    it 'assembles a link to title search and puts it in a list' do
-      links = title_links title_doc
-      expect(links).to match '<ul><li><a href="/?search_field=title&amp;q=Some+Title">Some Title</a></li><li>' \
-                             '<a href="/?search_field=title&amp;q=Another+Title">Another Title</a></li></ul>'
     end
   end
 

--- a/spec/helpers/search_links_helper_spec.rb
+++ b/spec/helpers/search_links_helper_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchLinksHelper, type: :helper do
+  describe '#other_subjectify' do
+    let (:field_data) { ['Power Amplifiers',
+                         'Research',
+                         'Fluid Mechanics and Thermodynamics'] }
+    let (:other_subjects_doc) { { value: field_data } }
+
+    it 'provides links to general subject search based on the given other subjects' do
+      full_subject = other_subjectify other_subjects_doc
+      expect(full_subject).to eq('<ul><li><a class="search-subject" title="Search: Power Amplifiers" ' \
+                                 'href="/?search_field=subject&amp;q=Power+Amplifiers">Power Amplifiers' \
+                                 '</a></li><li><a class="search-subject" title="Search: Research" ' \
+                                 'href="/?search_field=subject&amp;q=Research">Research</a></li><li>' \
+                                 '<a class="search-subject" title="Search: Fluid Mechanics and Thermodynamics" ' \
+                                 'href="/?search_field=subject&amp;q=Fluid+Mechanics+and+Thermodynamics">' \
+                                 'Fluid Mechanics and Thermodynamics</a></li></ul>')
+    end
+  end
+
+  describe '#genre_links' do
+    let (:field_data) { ['Film adaptations', 'Feature Films'] }
+    let (:genre_doc) { { value: field_data } }
+
+    it 'assembles an unordered list of links to genre search' do
+      links = genre_links genre_doc
+      expect(links).to eq '<ul><li><a href="/?f[genre_full_facet][]=Film+adaptations">Film adaptations</a>' \
+                          '</li><li><a href="/?f[genre_full_facet][]=Feature+Films">Feature Films</a></li></ul>'
+    end
+  end
+
+  describe '#series_links' do
+    let (:series_data) { ['Lecture Notes in Electrical Engineering, 1876-1100 ; 554'] }
+    let (:series_title_strict_data) { ['Lecture Notes in Electrical Engineering'] }
+
+    context 'when there is a series value and a strict version of the series title' do
+      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        expect(link).to eql '<ul><li><a class="search-series" title="Search: Lecture Notes in ' \
+                            'Electrical Engineering" ' \
+                            'href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">' \
+                            'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
+      end
+    end
+
+    context 'when there is a series value but no strict version of the series title' do
+      let (:link_doc) { { value: series_data, document: {} } }
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering, ' \
+                      '1876-1100 ; 554" href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering' \
+                      '%2C+1876-1100+%3B+554">Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li></ul>'
+        expect(link).to eql link_expect
+      end
+    end
+
+    context 'when there are multiple series values and strict versions of the series title' do
+      let (:link_doc) { { value: series_data, document: { series_title_strict_tsim: series_title_strict_data } } }
+
+      before do
+        series_data << 'Series Title 2, 1999, abc123'
+        series_title_strict_data << 'Series Title 2'
+      end
+
+      it 'assembles the link correctly' do
+        link = series_links link_doc
+        link_expect = '<ul><li><a class="search-series" title="Search: Lecture Notes in Electrical Engineering" ' \
+                      'href="/?search_field=series&amp;q=Lecture+Notes+in+Electrical+Engineering">' \
+                      'Lecture Notes in Electrical Engineering, 1876-1100 ; 554</a></li><li><a class="search-series" ' \
+                      'title="Search: Series Title 2" href="/?search_field=series&amp;q=Series+Title+2">Series ' \
+                      'Title 2, 1999, abc123</a></li></ul>'
+        expect(link).to eql link_expect
+      end
+    end
+  end
+
+  describe '#title_links' do
+    let (:field_data) { ['Some Title', 'Another Title'] }
+    let (:title_doc) { { value: field_data } }
+
+    it 'assembles a link to title search and puts it in a list' do
+      links = title_links title_doc
+      expect(links).to match '<ul><li><a href="/?search_field=title&amp;q=Some+Title">Some Title</a></li><li>' \
+                             '<a href="/?search_field=title&amp;q=Another+Title">Another Title</a></li></ul>'
+    end
+  end
+end

--- a/spec/helpers/search_links_helper_spec.rb
+++ b/spec/helpers/search_links_helper_spec.rb
@@ -90,4 +90,15 @@ RSpec.describe SearchLinksHelper, type: :helper do
                              '<a href="/?search_field=title&amp;q=Another+Title">Another Title</a></li></ul>'
     end
   end
+
+  describe '#thesis_dept_links' do
+    let (:field_data) { ['Number One Department', 'Number Two Department'] }
+    let (:thesis_dept_doc) { { value: field_data } }
+
+    it 'assembles links to thesis department facet search and puts it in a list' do
+      links = thesis_dept_links thesis_dept_doc
+      expect(links).to match '<ul><li><a href="/?f[thesis_dept_facet][]=Number+One+Department">Number One Department</a></li>' \
+                             '<li><a href="/?f[thesis_dept_facet][]=Number+Two+Department">Number Two Department</a></li></ul>'
+    end
+  end
 end

--- a/spec/helpers/search_links_helper_spec.rb
+++ b/spec/helpers/search_links_helper_spec.rb
@@ -97,8 +97,9 @@ RSpec.describe SearchLinksHelper, type: :helper do
 
     it 'assembles links to thesis department facet search and puts it in a list' do
       links = thesis_dept_links thesis_dept_doc
-      expect(links).to match '<ul><li><a href="/?f[thesis_dept_facet][]=Number+One+Department">Number One Department</a></li>' \
-                             '<li><a href="/?f[thesis_dept_facet][]=Number+Two+Department">Number Two Department</a></li></ul>'
+      expect(links).to match '<ul><li><a href="/?f[thesis_dept_facet][]=Number+One+Department">Number One ' \
+                             'Department</a></li><li><a href="/?f[thesis_dept_facet][]=Number+Two+Departme' \
+                             'nt">Number Two Department</a></li></ul>'
     end
   end
 end


### PR DESCRIPTION
Display thesis departments as a list of links to a facet search for the thesis department.

Also, I refactored a number of link generating methods into their own helper module.  They were sharing a lot of code, so I put most of the logic for generating the links into a single function.

closes #765 

traject side: https://github.com/psu-libraries/psulib_traject/pull/473