### PR TITLE
Don’t show links to manifests if we’re going to render an IIIF viewer

### DIFF
--- a/app/models/external_links.rb
+++ b/app/models/external_links.rb
@@ -38,7 +38,13 @@ module ExternalLinks
     end
 
     def partial_links
-      @_source['partial_links_struct']
+      links = @_source['partial_links_struct']
+
+      if @_source['iiif_manifest_ssim'].present?
+        links.grep_v(/IIIF manifest/)
+      else
+        links
+      end
     end
 
     def suppl_links

--- a/spec/features/iiif_viewer_spec.rb
+++ b/spec/features/iiif_viewer_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe 'viewing a record', js: true, vcr: { record: :new_episodes } do
         expect(page).not_to have_content 'error'
       end
     end
+
+    it 'does not show a link to the IIIF manifest file' do
+      visit '/catalog/2025781'
+      expect(page).not_to have_link 'IIIF manifest'
+    end
   end
 
   context 'when the record has an ARK URL that redirects to the IIIF manifest' do

--- a/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL/does_not_show_a_link_to_the_IIIF_manifest_file.yml
+++ b/spec/fixtures/vcr_cassettes/viewing_a_record/when_the_record_has_an_IIIF_manifest_URL/does_not_show_a_link_to_the_IIIF_manifest_file.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://books.google.com/books?bibkeys=LCCN:74694843&jscmd=viewapi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - books.google.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 May 2023 20:42:04 GMT
+      Expires:
+      - Wed, 24 May 2023 20:42:04 GMT
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      - policyref="http://www.google.com/googlebooks/p3p.xml", CP="DSP NON ADM DEV
+        OUR BUS NAV COM INT STA"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=604800
+      Content-Type:
+      - application/javascript; charset=ISO-8859-1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Disposition:
+      - attachment; filename="f.txt"
+      Server:
+      - OFE/0.1
+      Set-Cookie:
+      - NID=511=PrP_6j6ejjPxOYlBnVIH9yWNM1ib5NfU5QGNdg5urTRh1Opa1_KJxqO-6_DxW27BG1JC7rMb3yr5ErPFDvEbub4F8sOu_tlrqhUQXVeMmjle-1QkgFD2VsUrW5XrwSDNlgGEPOqCNqs-lrcRwzYMxAiUSlFzFm11fDHgbpfGDys;
+        expires=Thu, 23-Nov-2023 20:42:04 GMT; path=/; domain=.google.com; HttpOnly
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: var _GBSBookInfo = {};
+  recorded_at: Wed, 24 May 2023 20:42:03 GMT
+- request:
+    method: get
+    uri: https://cat.libraries.psu.edu:28443/symwsbc/rest/standard/lookupTitleInfo?clientID=PSUCATALOG&includeAvailabilityInfo=true&includeBoundTogether=true&includeItemInfo=true&titleID=2025781
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - cat.libraries.psu.edu:28443
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 24 May 2023 20:42:04 GMT
+      Server:
+      - SirsiDynix IlsWS
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><LookupTitleInfoResponse
+        xmlns="http://schemas.sirsidynix.com/symws/standard"><TitleInfo><titleID>2025781</titleID><TitleAvailabilityInfo><totalCopiesAvailable>2</totalCopiesAvailable><libraryWithAvailableCopies>Special
+        Collections Library (UP)</libraryWithAvailableCopies><totalResvCopiesAvailable>0</totalResvCopiesAvailable><locationOfFirstAvailableItem>RARE-MAPS</locationOfFirstAvailableItem><holdable>false</holdable><bookable>false</bookable></TitleAvailabilityInfo><CallInfo><libraryID>UP-SPECCOL</libraryID><classificationID>LC</classificationID><callNumber>G3860
+        1776.G4 1961</callNumber><numberOfCopies>2</numberOfCopies><ItemInfo><itemID>000026874098</itemID><itemTypeID>MAP</itemTypeID><currentLocationID>RARE-MAPS</currentLocationID><homeLocationID>RARE-MAPS</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo><ItemInfo><itemID>000026879802</itemID><itemTypeID>MAP</itemTypeID><currentLocationID>RARE-MAPS</currentLocationID><homeLocationID>RARE-MAPS</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><numberOfBoundwithLinks>0</numberOfBoundwithLinks></TitleInfo></LookupTitleInfoResponse>
+  recorded_at: Wed, 24 May 2023 20:42:03 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/external_links_spec.rb
+++ b/spec/models/external_links_spec.rb
@@ -234,4 +234,74 @@ RSpec.describe ExternalLinks do
       }.with_indifferent_access])
     end
   end
+
+  describe '#online_version_links' do
+    let(:document) { { partial_links_struct: partial_links_struct } }
+    let(:online_version_links) { SolrDocument.new(document).online_version_links }
+    let(:partial_links_struct) {
+      [
+        '{"prefix":"Digitized copy:","text":"libraries.psu.edu","url":"https://libraries.psu.edu/the-digitized-thing","notes":""}',
+        '{"prefix":"","text":"IIIF manifest","url":"https://arks.libraries.psu.edu/ark:/42409/ii34w27","notes":"Note:"}'
+      ]
+    }
+
+    context "when the document's partial_links_struct is nil" do
+      let(:partial_links_struct) { nil }
+
+      it 'returns nil' do
+        expect(online_version_links).to be_nil
+      end
+    end
+
+    context "when the document's partial_links_struct is empty" do
+      let(:partial_links_struct) { [] }
+
+      it 'returns nil' do
+        expect(online_version_links).to be_nil
+      end
+    end
+
+    context "when the document's partial_links_struct is not empty" do
+      it 'returns the parsed links' do
+        expect(online_version_links).to eq(
+          [
+            {
+              prefix: 'Digitized copy: ',
+              text: 'libraries.psu.edu',
+              url: 'https://libraries.psu.edu/the-digitized-thing',
+              notes: nil
+            }.with_indifferent_access,
+            {
+              prefix: nil,
+              text: 'IIIF manifest',
+              url: 'https://arks.libraries.psu.edu/ark:/42409/ii34w27',
+              notes: ', Note'
+            }.with_indifferent_access
+          ]
+        )
+      end
+
+      context 'when the document has a iiif_manifest_ssim value' do
+        let(:document) {
+          {
+            partial_links_struct: partial_links_struct,
+            iiif_manifest_ssim: 'https://arks.libraries.psu.edu/ark:/42409/ii34w27'
+          }
+        }
+
+        it 'returns the parsed links excluding any IIIF manifest links' do
+          expect(online_version_links).to eq(
+            [
+              {
+                prefix: 'Digitized copy: ',
+                text: 'libraries.psu.edu',
+                url: 'https://libraries.psu.edu/the-digitized-thing',
+                notes: nil
+              }.with_indifferent_access
+            ]
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
...as requested by @ruthtillman a couple of weeks ago.