### PR TITLE
updating browser tools orb to successfully download chrome drivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,6 @@ jobs:
     steps:
     - browser-tools/install-chrome
     - browser-tools/install-chromedriver
-    - run:
-        name: Remove Cruft
-        command: rm *
     - checkout
     - restore_cache:
         keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   docker: circleci/docker@1.5.0
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.3
 
 jobs:
   release:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,11 @@ require 'capybara/rspec'
 require 'capybara/rails'
 require 'webmock/rspec'
 require 'view_component/test_helpers'
+require 'webdrivers'
+
+# TODO remove this when webdrivers updates
+# https://github.com/titusfortner/webdrivers/issues/247
+Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
 # allow connections to localhost, webdrivers
 WebMock.disable_net_connect!(


### PR DESCRIPTION
The current version of orb fails to install the correct chrome driver. The latest release has a solution. You can find the details here: https://github.com/CircleCI-Public/browser-tools-orb/releases 