### PR TITLE
ILL placement for closed libraries

### DIFF
--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -21,6 +21,7 @@ const availability = {
   reserveCirculationRules: reserveCirculationRules.reserve_circulation_rules,
   movedLocations: [],
   nonHoldableLocations: locations.non_holdable,
+  closedLibraries: locations.closed_libraries,
 
   sirsiUrl: '/availability/sirsi-data/?',
   sirsiItemUrl: '/availability/sirsi-item-data/?',
@@ -537,16 +538,20 @@ const availability = {
   },
 
   noRecalls(holdings) {
-    if (availability.allNonHoldableLocation(holdings)) {
+    if (availability.allNonHoldable(holdings)) {
       return true;
     }
 
     return false;
   },
 
-  allNonHoldableLocation(holdings) {
+  isClosedLibrary(holding) {
+    return availability.closedLibraries.includes(holding.libraryID);
+  },
+
+  allNonHoldable(holdings) {
     for (const holding of holdings) {
-      if (!availability.isNonHoldableLocation(holding)) {
+      if (!availability.isNonHoldableLocation(holding) && !availability.isClosedLibrary(holding)) {
         return false;
       }
     }

--- a/app/javascript/availability/index.js
+++ b/app/javascript/availability/index.js
@@ -551,7 +551,10 @@ const availability = {
 
   allNonHoldable(holdings) {
     for (const holding of holdings) {
-      if (!availability.isNonHoldableLocation(holding) && !availability.isClosedLibrary(holding)) {
+      if (
+        !availability.isNonHoldableLocation(holding) &&
+        !availability.isClosedLibrary(holding)
+      ) {
         return false;
       }
     }

--- a/app/javascript/availability/libraries_locations.json
+++ b/app/javascript/availability/libraries_locations.json
@@ -791,6 +791,10 @@
     "XTERNAL": "Associated Libraries",
     "YORK": "Penn State York"
   },
+  "closed_libraries": [
+    "FAYETTE",
+    "WSCRANTON"
+  ],
   "exclude_from_email_availability": {
     "CHECKEDOUT": "Checked out",
     "DARCHIVE-P": "Copy unavailable",

--- a/spec/javascript/availability/availability.spec.js
+++ b/spec/javascript/availability/availability.spec.js
@@ -1,25 +1,29 @@
 import $ from 'jquery';
 import availability from '../../../app/javascript/availability/index';
 import 'bootstrap';
-import React from 'react';
-import ReactDOM from 'react-dom';
 
-global.$ = global.jQuery = $;
+global.$ = $;
+global.jQuery = $;
 
 jest.mock(
   '../../../app/javascript/availability/libraries_locations.json',
   () => ({
     closed_libraries: ['WSCRANTON'],
-    locations: {"STACKS-WS": "Stacks - General Collection",
-                "STACKS-AB": "Stacks - General Collection",
-                "STACKS-FE": "Stacks - General Collection",
-                "STACKS-YK": "Stacks - General Collection"},
-    libraries: {"WSCRANTON": "Penn State Scranton",
-                "ABINGTON": "Penn State Abington",
-                "FAYETTE": "Penn State Fayette",
-                "YORK": "Penn State York"},
-    non_holdable: ["CHECKEDOUT"],
-  }), { virtual: true }
+    locations: {
+      'STACKS-WS': 'Stacks - General Collection',
+      'STACKS-AB': 'Stacks - General Collection',
+      'STACKS-FE': 'Stacks - General Collection',
+      'STACKS-YK': 'Stacks - General Collection',
+    },
+    libraries: {
+      WSCRANTON: 'Penn State Scranton',
+      ABINGTON: 'Penn State Abington',
+      FAYETTE: 'Penn State Fayette',
+      YORK: 'Penn State York',
+    },
+    non_holdable: ['CHECKEDOUT'],
+  }),
+  { virtual: true }
 );
 jest.mock('react-dom', () => ({
   render: jest.fn(),
@@ -40,13 +44,15 @@ beforeEach(() => {
 describe('when a holdable record is only in a closed library', () => {
   test('I Want It directs to ILLiad placement', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'WSCRANTON',
-        locationID: 'STACKS-WS',
-        holdable: 'true',
-        reserveCollectionID: '',
-      }],
+      [
+        {
+          catkey: '0',
+          libraryID: 'WSCRANTON',
+          locationID: 'STACKS-WS',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
@@ -61,24 +67,25 @@ describe('when a holdable record is only in a closed library', () => {
   });
 });
 
-
 describe('when a holdable record is in a closed library and a holdable location', () => {
   test('I Want It directs to Symphony placement', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'WSCRANTON',
-        locationID: 'STACKS-WS',
-        holdable: 'true',
-        reserveCollectionID: '',
-      },
-      {
-        catkey: '0',
-        libraryID: 'FAYETTE',
-        locationID: 'STACKS-FE',
-        holdable: 'true',
-        reserveCollectionID: '',
-      }]
+      [
+        {
+          catkey: '0',
+          libraryID: 'WSCRANTON',
+          locationID: 'STACKS-WS',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+        {
+          catkey: '0',
+          libraryID: 'FAYETTE',
+          locationID: 'STACKS-FE',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
@@ -96,20 +103,22 @@ describe('when a holdable record is in a closed library and a holdable location'
 describe('when a holdable record is in a closed library and a non holdable location', () => {
   test('I Want It directs to ILLiad placement', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'WSCRANTON',
-        locationID: 'STACKS-WS',
-        holdable: 'true',
-        reserveCollectionID: '',
-      },
-      {
-        catkey: '0',
-        libraryID: 'ABINGTON',
-        locationID: 'CHECKEDOUT',
-        holdable: 'true',
-        reserveCollectionID: '',
-      }],
+      [
+        {
+          catkey: '0',
+          libraryID: 'WSCRANTON',
+          locationID: 'STACKS-WS',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+        {
+          catkey: '0',
+          libraryID: 'ABINGTON',
+          locationID: 'CHECKEDOUT',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
@@ -125,15 +134,17 @@ describe('when a holdable record is in a closed library and a non holdable locat
 });
 
 describe('when a holdable record is only in a non holdable location', () => {
-  test('I Want It directs to ILLiad placement', () => {    
+  test('I Want It directs to ILLiad placement', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'ABINGTON',
-        locationID: 'CHECKEDOUT',
-        holdable: 'true',
-        reserveCollectionID: '',
-      }],
+      [
+        {
+          catkey: '0',
+          libraryID: 'ABINGTON',
+          locationID: 'CHECKEDOUT',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
@@ -151,13 +162,15 @@ describe('when a holdable record is only in a non holdable location', () => {
 describe('when a holdable record is in a holdable location', () => {
   test('I Want It directs to Symphony placement', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'YORK',
-        locationID: 'STACKS-YK',
-        holdable: 'true',
-        reserveCollectionID: '',
-      }]
+      [
+        {
+          catkey: '0',
+          libraryID: 'YORK',
+          locationID: 'STACKS-YK',
+          holdable: 'true',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
@@ -175,13 +188,15 @@ describe('when a holdable record is in a holdable location', () => {
 describe('when a record is not holdable', () => {
   test('I Want It is not rendered', () => {
     const allHoldingsMock = [
-      [{
-        catkey: '0',
-        libraryID: 'ABINGTON',
-        locationID: 'STACKS-AB',
-        holdable: 'false',
-        reserveCollectionID: '',
-      }]
+      [
+        {
+          catkey: '0',
+          libraryID: 'ABINGTON',
+          locationID: 'STACKS-AB',
+          holdable: 'false',
+          reserveCollectionID: '',
+        },
+      ],
     ];
 
     availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);

--- a/spec/javascript/availability/availability.spec.js
+++ b/spec/javascript/availability/availability.spec.js
@@ -1,0 +1,197 @@
+import $ from 'jquery';
+import availability from '../../../app/javascript/availability/index';
+import 'bootstrap';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+global.$ = global.jQuery = $;
+
+jest.mock(
+  '../../../app/javascript/availability/libraries_locations.json',
+  () => ({
+    closed_libraries: ['WSCRANTON'],
+    locations: {"STACKS-WS": "Stacks - General Collection",
+                "STACKS-AB": "Stacks - General Collection",
+                "STACKS-FE": "Stacks - General Collection",
+                "STACKS-YK": "Stacks - General Collection"},
+    libraries: {"WSCRANTON": "Penn State Scranton",
+                "ABINGTON": "Penn State Abington",
+                "FAYETTE": "Penn State Fayette",
+                "YORK": "Penn State York"},
+    non_holdable: ["CHECKEDOUT"],
+  }), { virtual: true }
+);
+jest.mock('react-dom', () => ({
+  render: jest.fn(),
+}));
+const summaryHoldingsMock = {};
+
+beforeEach(() => {
+  document.body.innerHTML = `<div class="availability" data-keys="0">
+  <div class="no-recalls-button text-right d-none mb-2">
+    <a href="ill_url" class="btn btn-primary pr-4 pl-4">I Want It</a>
+  </div>
+  <div class="hold-button text-right d-none mb-2">
+  <a href="symphony_url" class="btn btn-primary pr-4 pl-4">I Want It</a>
+  </div>
+  </div>`;
+});
+
+describe('when a holdable record is only in a closed library', () => {
+  test('I Want It directs to ILLiad placement', () => {
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'WSCRANTON',
+        locationID: 'STACKS-WS',
+        holdable: 'true',
+        reserveCollectionID: '',
+      }],
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(true);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(true);
+  });
+});
+
+
+describe('when a holdable record is in a closed library and a holdable location', () => {
+  test('I Want It directs to Symphony placement', () => {
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'WSCRANTON',
+        locationID: 'STACKS-WS',
+        holdable: 'true',
+        reserveCollectionID: '',
+      },
+      {
+        catkey: '0',
+        libraryID: 'FAYETTE',
+        locationID: 'STACKS-FE',
+        holdable: 'true',
+        reserveCollectionID: '',
+      }]
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(false);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(true);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(true);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(false);
+  });
+});
+
+describe('when a holdable record is in a closed library and a non holdable location', () => {
+  test('I Want It directs to ILLiad placement', () => {
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'WSCRANTON',
+        locationID: 'STACKS-WS',
+        holdable: 'true',
+        reserveCollectionID: '',
+      },
+      {
+        catkey: '0',
+        libraryID: 'ABINGTON',
+        locationID: 'CHECKEDOUT',
+        holdable: 'true',
+        reserveCollectionID: '',
+      }],
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(true);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(true);
+  });
+});
+
+describe('when a holdable record is only in a non holdable location', () => {
+  test('I Want It directs to ILLiad placement', () => {    
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'ABINGTON',
+        locationID: 'CHECKEDOUT',
+        holdable: 'true',
+        reserveCollectionID: '',
+      }],
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(true);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(true);
+  });
+});
+
+describe('when a holdable record is in a holdable location', () => {
+  test('I Want It directs to Symphony placement', () => {
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'YORK',
+        locationID: 'STACKS-YK',
+        holdable: 'true',
+        reserveCollectionID: '',
+      }]
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(false);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(true);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(true);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(false);
+  });
+});
+
+describe('when a record is not holdable', () => {
+  test('I Want It is not rendered', () => {
+    const allHoldingsMock = [
+      [{
+        catkey: '0',
+        libraryID: 'ABINGTON',
+        locationID: 'STACKS-AB',
+        holdable: 'false',
+        reserveCollectionID: '',
+      }]
+    ];
+
+    availability.availabilityDisplay(allHoldingsMock, summaryHoldingsMock);
+
+    const noRecallsButton = document.querySelector('.no-recalls-button');
+    const holdButton = document.querySelector('.hold-button');
+
+    expect(holdButton.classList.contains('d-none')).toBe(true);
+    expect(holdButton.classList.contains('d-md-inline')).toBe(false);
+    expect(noRecallsButton.classList.contains('d-none')).toBe(true);
+    expect(noRecallsButton.classList.contains('d-md-inline')).toBe(false);
+  });
+});

--- a/spec/javascript/availability/availability.spec.js
+++ b/spec/javascript/availability/availability.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import $ from 'jquery';
 import availability from '../../../app/javascript/availability/index';
 import 'bootstrap';


### PR DESCRIPTION
Fixes #1211 

Determined at the library rather than location level, holdable items that can be found in currently closed libraries but are not in another holdable location are directed to ILL placement. 