### PR TITLE
serials edge case fix

### DIFF
--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -30,9 +30,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
 
               <ul style={listStyle}>
                 {summaryHoldings[locationID].length > 1 ? (
-                  <ul
-                    style={nestedListStyle}
-                  >
+                  <ul style={nestedListStyle}>
                     {/* Summaries for multiple holding statements in a library location pair */}
                     {summaryHoldings[locationID].map((data, index) => (
                       <li key={`location${index}`}>
@@ -44,9 +42,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                           {/* Indexes */}
                           {data.index.length > 0 && (
                             <li>
-                              <ul
-                                style={nestedListStyle}
-                              >
+                              <ul style={nestedListStyle}>
                                 {data.index.map((indexes, i) => (
                                   <li key={`index${i}`}>Indexes: {indexes}</li>
                                 ))}
@@ -56,9 +52,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                           {/* Supplements */}
                           {data.supplement.length > 0 && (
                             <li>
-                              <ul
-                                style={nestedListStyle}
-                              >
+                              <ul style={nestedListStyle}>
                                 {data.supplement.map((supplement, i) => (
                                   <li key={`supplement${i}`}>
                                     Supplements: {supplement}
@@ -72,9 +66,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                     ))}
                   </ul>
                 ) : (
-                  <ul
-                    style={nestedListStyle}
-                  >
+                  <ul style={nestedListStyle}>
                     {/* Summaries for a single holding statement in a library location pair */}
                     {locationData.summary.map((summary, i) => (
                       <li key={`summary${i}`}>{summary}</li>

--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -24,10 +24,29 @@ const SummaryHoldings = ({ summaryHoldings }) => {
               <div className="h6">{locationName}: Holdings Summary</div>
 
               <ul style={listStyle}>
-                {/* Summaries */}
-                {locationData.summary.map((summary, i) => (
-                  <li key={`summary${i}`}>{summary}</li>
-                ))}
+               
+                {summaryHoldings[locationID].length > 1 ? (
+                  <ul style={listStyle}>
+                    {/* Summaries */}
+                    {summaryHoldings[locationID].map((data, index) => (
+                      <li key={`location${index}`}>
+                        <div>Call Number: {data.call_number}</div>
+                        <ul>
+                          {data.summary.map((summary, i) => (
+                            <li key={`summary${i}`}>{summary}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <ul style={listStyle}>
+                    {/* Summaries */}
+                    {locationData.summary.map((summary, i) => (
+                      <li key={`summary${i}`}>{summary}</li>
+                    ))}
+                  </ul>
+                )}
 
                 {/* Indexes */}
                 {locationData.index.length > 0 && (

--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -26,11 +26,11 @@ const SummaryHoldings = ({ summaryHoldings }) => {
               <ul style={listStyle}>
                
                 {summaryHoldings[locationID].length > 1 ? (
-                  <ul style={listStyle}>
+                  <ul style={{ listStyleType: 'none', padding: 0, marginLeft: '0' }}>
                     {/* Summaries */}
                     {summaryHoldings[locationID].map((data, index) => (
                       <li key={`location${index}`}>
-                        <div>Call Number: {data.call_number}</div>
+                        <div>{data.call_number}</div>
                         <ul>
                           {data.summary.map((summary, i) => (
                             <li key={`summary${i}`}>{summary}</li>
@@ -40,7 +40,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                     ))}
                   </ul>
                 ) : (
-                  <ul style={listStyle}>
+                  <ul style={{ listStyleType: 'none', padding: 0, marginLeft: '0' }}>
                     {/* Summaries */}
                     {locationData.summary.map((summary, i) => (
                       <li key={`summary${i}`}>{summary}</li>

--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -24,10 +24,15 @@ const SummaryHoldings = ({ summaryHoldings }) => {
               <div className="h6">{locationName}: Holdings Summary</div>
 
               <ul style={listStyle}>
-               
                 {summaryHoldings[locationID].length > 1 ? (
-                  <ul style={{ listStyleType: 'none', padding: 0, marginLeft: '0' }}>
-                    {/* Summaries */}
+                  <ul
+                    style={{
+                      listStyleType: 'none',
+                      padding: 0,
+                      marginLeft: '0',
+                    }}
+                  >
+                    {/* Summaries for multiple holding statements in a library location pair */}
                     {summaryHoldings[locationID].map((data, index) => (
                       <li key={`location${index}`}>
                         <div>{data.call_number}</div>
@@ -35,49 +40,87 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                           {data.summary.map((summary, i) => (
                             <li key={`summary${i}`}>{summary}</li>
                           ))}
+                          {/* Indexes */}
+                          {data.index.length > 0 && (
+                            <li>
+                              <ul
+                                style={{
+                                  listStyleType: 'none',
+                                  padding: 0,
+                                  marginLeft: '0',
+                                }}
+                              >
+                                {data.index.map((indexes, i) => (
+                                  <li key={`index${i}`}>Indexes: {indexes}</li>
+                                ))}
+                              </ul>
+                            </li>
+                          )}
+                          {/* Supplements */}
+                          {data.supplement.length > 0 && (
+                            <li>
+                              <ul
+                                style={{
+                                  listStyleType: 'none',
+                                  padding: 0,
+                                  marginLeft: '0',
+                                }}
+                              >
+                                {data.supplement.map((supplement, i) => (
+                                  <li key={`supplement${i}`}>
+                                    Supplements: {supplement}
+                                  </li>
+                                ))}
+                              </ul>
+                            </li>
+                          )}
                         </ul>
                       </li>
                     ))}
                   </ul>
                 ) : (
-                  <ul style={{ listStyleType: 'none', padding: 0, marginLeft: '0' }}>
-                    {/* Summaries */}
+                  <ul
+                    style={{
+                      listStyleType: 'none',
+                      padding: 0,
+                      marginLeft: '0',
+                    }}
+                  >
+                    {/* Summaries for a single holding statement in a library location pair */}
                     {locationData.summary.map((summary, i) => (
                       <li key={`summary${i}`}>{summary}</li>
                     ))}
+                    {/* Indexes */}
+                    {locationData.index.length > 0 && (
+                      <li>
+                        <div className="h6 mt-2">
+                          <span className="sr-only">{locationName}</span>
+                          Indexes
+                        </div>
+
+                        <ul style={listStyle}>
+                          {locationData.index.map((index, i) => (
+                            <li key={`index${i}`}>{index}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    )}
+                    {/* Supplements */}
+                    {locationData.supplement.length > 0 && (
+                      <li>
+                        <div className="h6 mt-2">
+                          <span className="sr-only">{locationName}</span>
+                          Supplements
+                        </div>
+
+                        <ul style={listStyle}>
+                          {locationData.supplement.map((supplement, i) => (
+                            <li key={`supplement${i}`}>{supplement}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    )}
                   </ul>
-                )}
-
-                {/* Indexes */}
-                {locationData.index.length > 0 && (
-                  <li>
-                    <div className="h6 mt-2">
-                      <span className="sr-only">{locationName}</span>
-                      Indexes
-                    </div>
-
-                    <ul style={listStyle}>
-                      {locationData.index.map((index, i) => (
-                        <li key={`index${i}`}>{index}</li>
-                      ))}
-                    </ul>
-                  </li>
-                )}
-
-                {/* Supplements */}
-                {locationData.supplement.length > 0 && (
-                  <li>
-                    <div className="h6 mt-2">
-                      <span className="sr-only">{locationName}</span>
-                      Supplements
-                    </div>
-
-                    <ul style={listStyle}>
-                      {locationData.supplement.map((supplement, i) => (
-                        <li key={`supplement${i}`}>{supplement}</li>
-                      ))}
-                    </ul>
-                  </li>
                 )}
               </ul>
             </React.Fragment>

--- a/app/javascript/availability/components/summary_holdings.jsx
+++ b/app/javascript/availability/components/summary_holdings.jsx
@@ -11,6 +11,11 @@ const SummaryHoldings = ({ summaryHoldings }) => {
     marginBottom: 0,
     listStyleType: 'none',
   };
+  const nestedListStyle = {
+    listStyleType: 'none',
+    padding: 0,
+    marginLeft: '0',
+  };
 
   return (
     <tr className="table-primary">
@@ -26,11 +31,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
               <ul style={listStyle}>
                 {summaryHoldings[locationID].length > 1 ? (
                   <ul
-                    style={{
-                      listStyleType: 'none',
-                      padding: 0,
-                      marginLeft: '0',
-                    }}
+                    style={nestedListStyle}
                   >
                     {/* Summaries for multiple holding statements in a library location pair */}
                     {summaryHoldings[locationID].map((data, index) => (
@@ -44,11 +45,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                           {data.index.length > 0 && (
                             <li>
                               <ul
-                                style={{
-                                  listStyleType: 'none',
-                                  padding: 0,
-                                  marginLeft: '0',
-                                }}
+                                style={nestedListStyle}
                               >
                                 {data.index.map((indexes, i) => (
                                   <li key={`index${i}`}>Indexes: {indexes}</li>
@@ -60,11 +57,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                           {data.supplement.length > 0 && (
                             <li>
                               <ul
-                                style={{
-                                  listStyleType: 'none',
-                                  padding: 0,
-                                  marginLeft: '0',
-                                }}
+                                style={nestedListStyle}
                               >
                                 {data.supplement.map((supplement, i) => (
                                   <li key={`supplement${i}`}>
@@ -80,11 +73,7 @@ const SummaryHoldings = ({ summaryHoldings }) => {
                   </ul>
                 ) : (
                   <ul
-                    style={{
-                      listStyleType: 'none',
-                      padding: 0,
-                      marginLeft: '0',
-                    }}
+                    style={nestedListStyle}
                   >
                     {/* Summaries for a single holding statement in a library location pair */}
                     {locationData.summary.map((summary, i) => (

--- a/spec/javascript/availability/components/summary_holdings.jsx.spec.js
+++ b/spec/javascript/availability/components/summary_holdings.jsx.spec.js
@@ -75,3 +75,44 @@ describe('when some summary holdings data is not present', () => {
     expect(queryByText('Supplements')).toBeNull();
   });
 });
+
+describe('when multiple holding statements are present', () => {
+  test('renders summaries, indexes, and supplements', () => {
+    const data = {
+      'PATTEE-3': [
+        {
+          call_number: 'PR9400 .M43',
+          summary: ['summary1'],
+          supplement: [],
+          index: [],
+        },
+        {
+          call_number: 'PR9400 .M44',
+          summary: ['summary2'],
+          supplement: ['supplemental info'],
+          index: ['index info'],
+        },
+      ],
+    };
+
+    const { getAllByRole, getByText } = render(
+      <SummaryHoldings summaryHoldings={data} />,
+      {
+        container: document.body.appendChild(document.createElement('tbody')),
+      }
+    );
+
+    const items = getAllByRole('listitem');
+    expect(items.length).toBe(8);
+    expect(items[0]).toHaveTextContent('PR9400 .M43');
+    expect(items[1]).toHaveTextContent('summary1');
+    expect(items[2]).toHaveTextContent('PR9400 .M44');
+    expect(items[3]).toHaveTextContent('summary2');
+    expect(items[5]).toHaveTextContent('Indexes: index info');
+    expect(items[7]).toHaveTextContent('Supplements: supplemental info');
+
+    expect(
+      getByText('Pattee - Stacks 3: Holdings Summary')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
fixes https://github.com/psu-libraries/psulib_traject/issues/492

Previously summaries, indexes, and supplements info was only being pulled for the first holdings statement for a given library/location pair. 

When there is only one holdings statement, the display is unchanged. When there are multiple holdings statements for a library/location pair, the call number is displayed for each holding statement with summaries, indexes, and supplements nested in a bulleted list beneath.