### PR TITLE
refactor specs

### DIFF
--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -145,6 +145,7 @@ development:
 test:
   <<: *default
   compile: true
+  compiler_strategy: mtime
 
   # Compile test packs to a separate directory
   public_output_path: packs-test


### PR DESCRIPTION
Changing complier strategy from digest to mtime to improve speed. Brings test suite time down from ~28 mins to 8 mins.