### PR TITLE
Preview/solr9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
   test:
     docker:
       - image: cimg/ruby:3.1.2-browsers
-      - image: redis:5.0.7
+      - image: redis:7.0.7
       - image: harbor.k8s.libraries.psu.edu/library/solr:9.5.0
         environment:
           SOLR_STOP_WAIT: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,9 @@ services:
     ports:
       - "${APP_PORT:-3000}:3000"
   solr:
-    image: harbor.k8s.libraries.psu.edu/library/solr:8.11.2
+    image: harbor.k8s.libraries.psu.edu/library/solr:9.5.0
+    environment:
+      SOLR_STOP_WAIT: 1
     restart: always
     volumes:
     - solr-data:/var/solr

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -12,7 +12,7 @@
 
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
 
-  <luceneMatchVersion>7.4.0</luceneMatchVersion>
+  <luceneMatchVersion>9.5.0</luceneMatchVersion>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
 

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -10,7 +10,7 @@
 
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
 
-  <luceneMatchVersion>9.9</luceneMatchVersion>
+  <luceneMatchVersion>8.11</luceneMatchVersion>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
 


### PR DESCRIPTION
- updates solr in CI, and docker-compose
- updates lucene version in solrconfig
- removes deprecated jmx config 
- removes unreachable libs. 

lucene version is at 8.11 because that is what we are running in prod right now. we should be able to run this code in our current qa setup, and migrate to solr 9. once we've migrated our whole fleet to solr 9, we can bump lucene version if we want to.