### PR TITLE
1053 limit search terms

### DIFF
--- a/app/models/clause_count_limiter.rb
+++ b/app/models/clause_count_limiter.rb
@@ -1,23 +1,21 @@
+# frozen_string_literal: true
+
 module ClauseCountLimiter
   # Limits the number of clauses allowed in a search field. Varies by search field type.
   def limit_clause_count(solr_parameters)
-    return unless is_query_present?(solr_parameters)
+    return unless query_present?(solr_parameters)
 
     length = case blacklight_params['search_field']
              when 'all_fields'
                # 10 terms, 1 will be added while truncating
                10
-             when 'title'
-               # 27 terms + "edismax", "qf", "title_qf", "pf", "title_pf", "pf3", "title_pf3", "pf2", "title_pf2"
+             when 'title', 'author'
+               # 27 terms + "edismax", "qf", "title/author_qf", "pf", "title/author_pf", "pf3", "title/author_pf3",
+               # "pf2", "title/author_pf2"
                36
-             when 'author'
-               # 27 terms + "edismax", "qf", "author_qf", "pf", "author_pf", "pf3", "author_pf3", "pf2", "author_pf2"
-               36
-             when 'subject'
+             when 'subject', 'isbn_issn'
                # 6 + "edismax",  "qf", "subject_qf", "pf", "subject_pf", "pf3", "subject_pf3", "pf2", "subject_pf2"
-               15
-             when 'isbn_issn'
-               # 9 + "edismax", "qf", "isbn_issn_qf", "pf", "pf3", "pf2"
+               # or # 9 + "edismax", "qf", "isbn_issn_qf", "pf", "pf3", "pf2"
                15
              else
                # 20 fallback for any other search field such as publisher, series_statement,
@@ -30,12 +28,12 @@ module ClauseCountLimiter
 
   private
 
-    def is_query_present?(solr_parameters)
+    def query_present?(solr_parameters)
       solr_parameters[:q].present? && blacklight_params[:q].present?
     end
 
     def get_query_length(solr_parameters)
-      solr_parameters[:q].split(/\b/).select { |x| x.match?(/\w/) }.length
+      solr_parameters[:q].split(/\b/).grep(/\w/).length
     end
 
     def truncate_query(solr_parameters, length)

--- a/app/models/clause_count_limiter.rb
+++ b/app/models/clause_count_limiter.rb
@@ -1,0 +1,45 @@
+module ClauseCountLimiter
+  # Limits the number of clauses allowed in a search field. Varies by search field type.
+  def limit_clause_count(solr_parameters)
+    return unless is_query_present?(solr_parameters)
+
+    length = case blacklight_params['search_field']
+             when 'all_fields'
+               # 10 terms, 1 will be added while truncating
+               10
+             when 'title'
+               # 27 terms + "edismax", "qf", "title_qf", "pf", "title_pf", "pf3", "title_pf3", "pf2", "title_pf2"
+               36
+             when 'author'
+               # 27 terms + "edismax", "qf", "author_qf", "pf", "author_pf", "pf3", "author_pf3", "pf2", "author_pf2"
+               36
+             when 'subject'
+               # 6 + "edismax",  "qf", "subject_qf", "pf", "subject_pf", "pf3", "subject_pf3", "pf2", "subject_pf2"
+               15
+             when 'isbn_issn'
+               # 9 + "edismax", "qf", "isbn_issn_qf", "pf", "pf3", "pf2"
+               15
+             else
+               # 20 fallback for any other search field such as publisher, series_statement,
+               # work_entry and genre_headings
+               20
+             end
+
+    truncate_query(solr_parameters, length) unless blacklight_params['search_field'] == 'call_number'
+  end
+
+  private
+
+    def is_query_present?(solr_parameters)
+      solr_parameters[:q].present? && blacklight_params[:q].present?
+    end
+
+    def get_query_length(solr_parameters)
+      solr_parameters[:q].split(/\b/).select { |x| x.match?(/\w/) }.length
+    end
+
+    def truncate_query(solr_parameters, length)
+      solr_parameters[:q] = solr_parameters[:q].truncate_words(length + 1, separator: /\W+/, omission: '') unless
+      get_query_length(solr_parameters) <= length
+    end
+end

--- a/app/models/clause_count_limiter.rb
+++ b/app/models/clause_count_limiter.rb
@@ -7,7 +7,7 @@ module ClauseCountLimiter
 
     length = case blacklight_params['search_field']
              when 'all_fields'
-               # 10 terms, 1 will be added while truncating
+               # 10 terms
                10
              when 'title', 'author'
                # 27 terms + "edismax", "qf", "title/author_qf", "pf", "title/author_pf", "pf3", "title/author_pf3",
@@ -40,7 +40,7 @@ module ClauseCountLimiter
     end
 
     def truncate_query(solr_parameters, length)
-      solr_parameters[:q] = solr_parameters[:q].truncate_words(length + 1, separator: /\W+/, omission: '') unless
+      solr_parameters[:q] = solr_parameters[:q].truncate_words(length, separator: /\W+/, omission: '') unless
       get_query_length(solr_parameters) <= length
     end
 end

--- a/app/models/clause_count_limiter.rb
+++ b/app/models/clause_count_limiter.rb
@@ -23,7 +23,10 @@ module ClauseCountLimiter
                20
              end
 
-    truncate_query(solr_parameters, length) unless blacklight_params['search_field'] == 'call_number'
+    unless blacklight_params['search_field'] == 'call_number' || solr_parameters[:defType] == 'lucene'
+      truncate_query(solr_parameters,
+                     length)
+    end
   end
 
   private

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,8 +4,9 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  include ClauseCountLimiter
   self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr,
-                                   :add_all_online_to_query]
+                                   :add_all_online_to_query, :limit_clause_count]
 
   def add_all_online_to_query(solr_parameters)
     if campus_facet_all_online_query?(solr_parameters)

--- a/spec/models/clause_count_limiter_spec.rb
+++ b/spec/models/clause_count_limiter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClauseCountLimiter, type: :helper do
+  def count_search_terms(term_string)
+    term_string.split.length
+  end
+  context 'when searching all fields' do
+    let(:blacklight_params) { { 'search_field' => 'all_fields', q: 'one' } }
+
+    it 'limits to 10 terms' do
+      solr_parameters = { q: 'one two three four five six seven eight nine ten eleven twelve thirteen' }
+      limit_clause_count(solr_parameters)
+      expect(solr_parameters[:q]).to eq 'one two three four five six seven eight nine ten'
+    end
+  end
+
+  context 'when searching author' do
+    let(:blacklight_params) { { 'search_field' => 'author', q: 'one' } }
+
+    it 'limits terms to 36' do
+      solr_parameters = { q: 'Bork ' * 40 }
+      limit_clause_count(solr_parameters)
+      expect(count_search_terms(solr_parameters[:q])).to eq(36)
+    end
+  end
+
+  context 'when searching title' do
+    let(:blacklight_params) { { 'search_field' => 'title', q: 'one' } }
+
+    it 'limits terms to 36' do
+      solr_parameters = { q: 'Meee ' * 40 }
+      limit_clause_count(solr_parameters)
+      expect(count_search_terms(solr_parameters[:q])).to eq(36)
+    end
+  end
+
+  context 'when searching subject' do
+    let(:blacklight_params) { { 'search_field' => 'subject', q: 'one' } }
+
+    it 'limits terms to 15' do
+      solr_parameters = { q: 'Wakka ' * 40 }
+      limit_clause_count(solr_parameters)
+      expect(count_search_terms(solr_parameters[:q])).to eq(15)
+    end
+  end
+
+  context 'when searching isbn' do
+    let(:blacklight_params) { { 'search_field' => 'isbn_issn', q: 'one' } }
+
+    it 'limits terms to 15' do
+      solr_parameters = { q: 'Bwawk ' * 40 }
+      limit_clause_count(solr_parameters)
+      expect(count_search_terms(solr_parameters[:q])).to eq(15)
+    end
+  end
+
+  context 'when searching all other fields' do
+    let(:blacklight_params) { { 'search_field' => 'publisher', q: 'one' } }
+
+    it 'limits terms to 21' do
+      solr_parameters = { q: 'Okay ' * 40 }
+      limit_clause_count(solr_parameters)
+      expect(count_search_terms(solr_parameters[:q])).to eq(20)
+    end
+  end
+end


### PR DESCRIPTION
closes #1053 

For edismax searches, we now truncate the number of search terms that we send to solr. This number is dependent on search field...for example, Title may still include many, whereas "All Fields" is capped at 10. This is to prevent solr failures caused by large numbers of search terms. The values for the fields are defined on the ticket.