### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,7 @@ jobs:
         command: |
           sudo apt-get update
           sudo apt-get install libu2f-udev -y
-    - browser-tools/install-chrome:
-        chrome-version: 119.0.6045.199 # TODO: remove when chromedriver downloads are fixed
-        replace-existing: true # TODO: remove when chromedriver downloads are fixed
-    - browser-tools/install-chromedriver
+    - browser-tools/install-browser-tools
     - checkout
     - restore_cache:
         keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   docker: circleci/docker@1.5.0
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
 
 jobs:
   release:


### PR DESCRIPTION
`spec/features/iiif_viewer_spec.rb` keeps failing off & on only in CI. The suspicion is that Chrome & ChromeDriver were pinned to fix a previous error where ChromeDriver didn't have a version to match a new version of chrome. That was never removed though, so it was keeping them back & causing the issue. This removes that & updates browser tools as well