### PR TITLE
turns on crawler_detector

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -398,6 +398,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field 'all_fields', label: 'Keyword'
 
+    # Add Crawler Detector. If the session is a crawler we will not save the search
+    config.crawler_detector  = lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot/ }
+
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -399,7 +399,7 @@ class CatalogController < ApplicationController
     config.add_search_field 'all_fields', label: 'Keyword'
 
     # Add Crawler Detector. If the session is a crawler we will not save the search
-    config.crawler_detector = lambda { |req| req.env['HTTP_USER_AGENT'].include?('bot') }
+    config.crawler_detector = lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot|nagios|facebook|python-requests|Python|Kuma|Grammarly/ }
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -399,7 +399,7 @@ class CatalogController < ApplicationController
     config.add_search_field 'all_fields', label: 'Keyword'
 
     # Add Crawler Detector. If the session is a crawler we will not save the search
-    config.crawler_detector  = lambda { |req| req.env['HTTP_USER_AGENT'] =~ /bot/ }
+    config.crawler_detector = lambda { |req| req.env['HTTP_USER_AGENT'].include?('bot') }
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate


### PR DESCRIPTION
blacklight will not store searches in the searches table if the crawler_detector evaluates to true. this will prevent writing needless amounts of data to the database. we may want to tweak the lambda to include AI bots as well. I'm going to run a report tomorrow. 