### PR TITLE
Removed WSCRANTON from 'closed_libraries' 

### DIFF
--- a/app/javascript/availability/libraries_locations.json
+++ b/app/javascript/availability/libraries_locations.json
@@ -802,7 +802,6 @@
   },
   "closed_libraries": [
     "FAYETTE",
-    "WSCRANTON",
     "NEWKEN",
     "DSL-CARL",
     "UP-ENGIN"

--- a/spec/javascript/availability/availability.spec.js
+++ b/spec/javascript/availability/availability.spec.js
@@ -49,7 +49,7 @@ describe('when a holdable record is only in a closed library', () => {
         {
           catkey: '0',
           libraryID: 'NEWKEN',
-          locationID: 'STACKS-WS',
+          locationID: 'STACKS-NK',
           holdable: 'true',
           reserveCollectionID: '',
         },
@@ -108,7 +108,7 @@ describe('when a holdable record is in a closed library and a non holdable locat
         {
           catkey: '0',
           libraryID: 'NEWKEN',
-          locationID: 'STACKS-WS',
+          locationID: 'STACKS-NK',
           holdable: 'true',
           reserveCollectionID: '',
         },

--- a/spec/javascript/availability/availability.spec.js
+++ b/spec/javascript/availability/availability.spec.js
@@ -9,15 +9,15 @@ global.jQuery = $;
 jest.mock(
   '../../../app/javascript/availability/libraries_locations.json',
   () => ({
-    closed_libraries: ['WSCRANTON'],
+    closed_libraries: ['NEWKEN'],
     locations: {
-      'STACKS-WS': 'Stacks - General Collection',
+      'STACKS-NK': 'Stacks - General Collection',
       'STACKS-AB': 'Stacks - General Collection',
       'STACKS-FE': 'Stacks - General Collection',
       'STACKS-YK': 'Stacks - General Collection',
     },
     libraries: {
-      WSCRANTON: 'Penn State Scranton',
+      NEWKEN: 'Penn State New Kensington',
       ABINGTON: 'Penn State Abington',
       FAYETTE: 'Penn State Fayette',
       YORK: 'Penn State York',
@@ -48,7 +48,7 @@ describe('when a holdable record is only in a closed library', () => {
       [
         {
           catkey: '0',
-          libraryID: 'WSCRANTON',
+          libraryID: 'NEWKEN',
           locationID: 'STACKS-WS',
           holdable: 'true',
           reserveCollectionID: '',
@@ -74,8 +74,8 @@ describe('when a holdable record is in a closed library and a holdable location'
       [
         {
           catkey: '0',
-          libraryID: 'WSCRANTON',
-          locationID: 'STACKS-WS',
+          libraryID: 'NEWKEN',
+          locationID: 'STACKS-NK',
           holdable: 'true',
           reserveCollectionID: '',
         },
@@ -107,7 +107,7 @@ describe('when a holdable record is in a closed library and a non holdable locat
       [
         {
           catkey: '0',
-          libraryID: 'WSCRANTON',
+          libraryID: 'NEWKEN',
           locationID: 'STACKS-WS',
           holdable: 'true',
           reserveCollectionID: '',


### PR DESCRIPTION
Scranton is back online.  I believe this should add Scranton back to allow holds.

Note: The tests I changed technically weren't broken.  I just did a text search for 'WSCRANTON' and figured I'd change those to be consistent.