### PR TITLE
added alt text to previous and next buttons

### DIFF
--- a/app/components/blacklight/search_context_component.html.erb
+++ b/app/components/blacklight/search_context_component.html.erb
@@ -1,0 +1,10 @@
+<div class='pagination-search-widgets'>
+
+  <div class="page-links">
+    <%= link_to_previous_document(aria: { label: 'Previous result' }) %> |
+
+    <%= item_page_entry_info %> |
+
+    <%= link_to_next_document(aria: { label: 'Next result' }) %>
+  </div>
+</div>

--- a/app/views/kaminari/blacklight_compact/_next_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_next_page.html.erb
@@ -4,6 +4,5 @@
     current_page:  a page object for the currently displayed page
     num_pages:     total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<%= link_to_unless current_page.last?, raw(t 'views.pagination_compact.next'), url, :rel => 'next', :remote => remote, :aria => { :label => "Next page" } %>
+    remote:        data-remote -%>
+<%= link_to_unless current_page.last?, raw((t ('views.pagination_compact.next'))), url, rel: 'next', remote: remote, aria: { label: 'Next result' } %>

--- a/app/views/kaminari/blacklight_compact/_next_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_next_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to_unless current_page.last?, raw(t 'views.pagination_compact.next'), url, :rel => 'next', :remote => remote, :aria => { :label => "Next page" } %>

--- a/app/views/kaminari/blacklight_compact/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_prev_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to_unless current_page.first?, raw(t 'views.pagination_compact.previous'), url, :rel => 'prev', :remote => remote, :aria => { :label => "Previous result" } %>

--- a/app/views/kaminari/blacklight_compact/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight_compact/_prev_page.html.erb
@@ -4,6 +4,5 @@
     current_page:  a page object for the currently displayed page
     num_pages:     total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<%= link_to_unless current_page.first?, raw(t 'views.pagination_compact.previous'), url, :rel => 'prev', :remote => remote, :aria => { :label => "Previous result" } %>
+    remote:        data-remote -%>
+<%= link_to_unless current_page.first?, raw((t ('views.pagination_compact.previous'))), url, rel: 'prev', remote: remote, aria: { label: 'Previous result' } %>


### PR DESCRIPTION
Fixes #1393 . If the current page is the first or last page, the alt text isn't changed and says "&larr Previous |" and "| Next &rarr", since it only affects every other page due to links. Every other page has the alt text saying previous result or next result as intended. Figured I should point that out.