### PR TITLE
Allow Accessiblity Tools to See Cover Image

### DIFF
--- a/app/javascript/book_covers/index.js
+++ b/app/javascript/book_covers/index.js
@@ -65,9 +65,8 @@ const bookCovers = {
         if (colonIndex > -1) title = title.substring(0, colonIndex);
         else if (slashIndex > -1) title = title.substring(0, slashIndex);
 
-        const parent = target.parent()
-        if (parent)
-          parent.removeAttr('aria-hidden');
+        const parent = target.parent();
+        if (parent) parent.removeAttr('aria-hidden');
 
         const altText = `Cover image for ${title.trim()}`;
         target.replaceWith(

--- a/app/javascript/book_covers/index.js
+++ b/app/javascript/book_covers/index.js
@@ -65,8 +65,11 @@ const bookCovers = {
         if (colonIndex > -1) title = title.substring(0, colonIndex);
         else if (slashIndex > -1) title = title.substring(0, slashIndex);
 
+        target.parent().removeAttr('aria-hidden');
+        
+        const altText = `Cover image for ${title.trim()}`
         target.replaceWith(
-          `<img class="img-fluid" src="${thumbUrlZoom1}" alt="Cover image for ${title.trim()}">`,
+          `<img class="img-fluid" src="${thumbUrlZoom1}" alt="${altText}" aria-label="${altText}">`,
         );
       }
     }

--- a/app/javascript/book_covers/index.js
+++ b/app/javascript/book_covers/index.js
@@ -65,7 +65,9 @@ const bookCovers = {
         if (colonIndex > -1) title = title.substring(0, colonIndex);
         else if (slashIndex > -1) title = title.substring(0, slashIndex);
 
-        target.parent().removeAttr('aria-hidden');
+        const parent = target.parent()
+        if (parent)
+          parent.removeAttr('aria-hidden');
 
         const altText = `Cover image for ${title.trim()}`;
         target.replaceWith(

--- a/app/javascript/book_covers/index.js
+++ b/app/javascript/book_covers/index.js
@@ -66,8 +66,8 @@ const bookCovers = {
         else if (slashIndex > -1) title = title.substring(0, slashIndex);
 
         target.parent().removeAttr('aria-hidden');
-        
-        const altText = `Cover image for ${title.trim()}`
+
+        const altText = `Cover image for ${title.trim()}`;
         target.replaceWith(
           `<img class="img-fluid" src="${thumbUrlZoom1}" alt="${altText}" aria-label="${altText}">`,
         );

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,13 +1,11 @@
-<% doc_presenter = document_presenter(document) %>
+å<% doc_presenter = document_presenter(document) %>
 
 <div class="row">
   <div class="col-sm-3 order-sm-10">
-    <div class="document-thumbnail">
-      <%= render(Blacklight::Document::ThumbnailComponent.new(
-                   presenter: document_presenter(document),
-                   counter: document_counter_with_offset(document_counter)
-                 )) %>
-    </div>
+    <%= render(Blacklight::Document::ThumbnailComponent.new(
+                  presenter: document_presenter(document),
+                  counter: document_counter_with_offset(document_counter)
+                )) %>
   </div>
 
   <div class="col-sm-9 order-sm-1">

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -2,10 +2,12 @@
 
 <div class="row">
   <div class="col-sm-3 order-sm-10">
-    <%= render(Blacklight::Document::ThumbnailComponent.new(
-                  presenter: document_presenter(document),
-                  counter: document_counter_with_offset(document_counter)
-                )) %>
+      <%= render(
+            Blacklight::Document::ThumbnailComponent.new(
+              presenter: document_presenter(document),
+              counter: document_counter_with_offset(document_counter)
+            )
+          ) %>
   </div>
 
   <div class="col-sm-9 order-sm-1">

--- a/spec/javascript/book_covers/index.spec.js
+++ b/spec/javascript/book_covers/index.spec.js
@@ -54,7 +54,7 @@ describe('bookCovers', () => {
         data: (key) =>
           key === 'title' ? 'Test Book Title: A Subtitle / Foo Bar' : null,
         replaceWith,
-        parent
+        parent,
       };
     });
 

--- a/spec/javascript/book_covers/index.spec.js
+++ b/spec/javascript/book_covers/index.spec.js
@@ -45,6 +45,7 @@ describe('bookCovers', () => {
       '</span>';
 
     const replaceWith = jest.fn();
+    const parent = jest.fn();
     const jQuery = jest.fn((selector) => {
       // Verify the selector is targeting the element with the correct ISBN
       expect(selector).toBe('[data-isbn*="9780972658355"]');
@@ -53,6 +54,7 @@ describe('bookCovers', () => {
         data: (key) =>
           key === 'title' ? 'Test Book Title: A Subtitle / Foo Bar' : null,
         replaceWith,
+        parent
       };
     });
 


### PR DESCRIPTION
Since adding alt text to cover images, the cover images found on listing pages where invisible to accessibility features. This PR adjusts how these specific images are presented so that they can still be recognized by various tools.