### PR TITLE
Removed RangeLimitHelper from failing file

### DIFF
--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -2,5 +2,4 @@
 
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
-
 end


### PR DESCRIPTION
Fixes the following pod failure. I saw that this RangeLimitHelper doesn't even appear in the Blacklight 7.41 or Blacklight Range Limit gem.

> │ /app/app/controllers/search_history_controller.rb:8:in '<class:SearchHistoryController>': uninitialized constant SearchHistoryController::RangeLimitHelper (NameError)                                           │
│                                                                                                                                                                                                                  │
│   helper RangeLimitHelper                                                                                                                                                                                        │
│          ^^^^^^^^^^^^^^^^                                                                                                                                                                                        │
│     from /app/app/controllers/search_history_controller.rb:3:in '<top (required)>'                                                                                                                               │
│     from /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'                                                                                                                                        │
│     from /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'                                                                                                            │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/core_ext/kernel.rb:26:in 'Kernel#require'                                                                                                │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/cref.rb:62:in 'Module#const_get'                                                                                                         │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/cref.rb:62:in 'Zeitwerk::Cref#get'                                                                                                       │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:173:in 'block in Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'                                                 │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/helpers.rb:47:in 'block in Zeitwerk::Loader::Helpers#ls'                                                                          │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/helpers.rb:25:in 'Array#each'                                                                                                     │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/helpers.rb:25:in 'Zeitwerk::Loader::Helpers#ls'                                                                                   │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:168:in 'Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'                                                          │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:17:in 'block (2 levels) in Zeitwerk::Loader::EagerLoad#eager_load'                                                  │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:16:in 'Hash#each'                                                                                                   │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:16:in 'block in Zeitwerk::Loader::EagerLoad#eager_load'                                                             │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:10:in 'Thread::Mutex#synchronize'                                                                                   │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/eager_load.rb:10:in 'Zeitwerk::Loader::EagerLoad#eager_load'                                                                      │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader.rb:431:in 'block in Zeitwerk::Loader.eager_load_all'                                                                              │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/registry/loaders.rb:10:in 'Array#each'                                                                                                   │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/registry/loaders.rb:10:in 'Zeitwerk::Registry::Loaders#each'                                                                             │
│     from /app/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.3/lib/zeitwerk/loader.rb:429:in 'Zeitwerk::Loader.eager_load_all'     

