### PR TITLE
downgrade blacklight_range_limit to fix pub year selector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'stackprof'
 gem 'blacklight', '~> 7.35'
 gem 'blacklight_advanced_search', '~> 8.0.0.alpha'
 gem 'blacklight-marc', '~> 8.0'
-gem 'blacklight_range_limit'
+gem 'blacklight_range_limit', '~> 8.1.0'
 
 group :development do
   gem 'better_errors'
@@ -73,5 +73,5 @@ group :test do
 end
 
 group :production, :test do
-  gem 'mysql2', '>= 0.5.6', '< 0.6.0'
+  gem 'mysql2', '>= 0.5.7', '< 0.6.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,9 +116,8 @@ GEM
     blacklight_advanced_search (8.0.0.alpha2)
       blacklight (>= 7.15, < 9)
       parslet
-    blacklight_range_limit (9.1.0)
-      blacklight (>= 7.25.2, < 9)
-      view_component (>= 2.54, < 5)
+    blacklight_range_limit (8.1.0)
+      blacklight (~> 7.0)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     bot_challenge_page (0.3.1)
@@ -294,7 +293,8 @@ GEM
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
-    mysql2 (0.5.6)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.5.10)
       date
       net-protocol
@@ -599,7 +599,7 @@ DEPENDENCIES
   blacklight (~> 7.35)
   blacklight-marc (~> 8.0)
   blacklight_advanced_search (~> 8.0.0.alpha)
-  blacklight_range_limit
+  blacklight_range_limit (~> 8.1.0)
   bootsnap
   bot_challenge_page (~> 0.3.1)
   bugsnag (~> 6.26)
@@ -617,7 +617,7 @@ DEPENDENCIES
   listen
   lograge
   memory_profiler
-  mysql2 (>= 0.5.6, < 0.6.0)
+  mysql2 (>= 0.5.7, < 0.6.0)
   net-imap
   net-pop
   net-smtp


### PR DESCRIPTION
Publication year facet is broken in QA. This puts blacklight_range_limit back to last compatible version. Also has a very small mysql upgrade that resolved a build issue