### PR TITLE
Adds configuration to bugsnag to ignore '/health' paths

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -7,6 +7,6 @@ Bugsnag.configure do |config|
   config.add_on_error(proc do |event|
     path = event.request&.dig(:path)
 
-    false if path&.start_with?('/health')
+    event.ignore! if path&.start_with?('/health')
   end)
 end


### PR DESCRIPTION
This will prevent our healthcheck endpoint from accumulating bugsnag errors when the application goes down.