### PR TITLE
Added deletion of preview deployments to pipeline 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@2.8.2
+  docker: circleci/docker@3.0.1
   browser-tools: circleci/browser-tools@1.5.3
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   docker: circleci/docker@2.8.2
+  browser-tools: circleci/browser-tools@1.5.3
 
 parameters:
 
@@ -299,9 +300,8 @@ jobs:
           ./bin/ci-rspec
 
 workflows:
-  version: 2
 
-  blacklight-delete-ci-cd:
+  delete-deployment:
     when:
       equal: [ "delete", << pipeline.parameters.GHA_Event >> ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@3.0.1
-  browser-tools: circleci/browser-tools@1.5.3
+  docker: circleci/docker@2.8.2
 
 parameters:
 
@@ -33,6 +32,9 @@ parameters:
   CLUSTERS_PROD:
     type: string
     default: "prod"
+  CLUSTERS_ULPROD:
+    type: string
+    default: "ulprod"
   REGISTRY_HOST:
     type: string
     default: "harbor.k8s.libraries.psu.edu"
@@ -49,7 +51,7 @@ commands:
           name: Prepare GitHub Access
           command: |
             ssh-keyscan github.com > ~/.ssh/known_hosts
-            git clone << pipeline.parameters.CONFIG_REPO_URL >>
+            git clone $CONFIG_REPO_URL
 
   compute-docker-tag:
     steps:
@@ -76,10 +78,12 @@ executors:
       - image: << parameters.registry_host >>/library/ci-utils:<< parameters.image_tag >>
 
 jobs:
+
   build-image:
     environment:
       REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>
       REGISTRY_REPO: "library/$CIRCLE_PROJECT_REPONAME"
+      TAG: <<pipeline.git.revision>>,<<pipeline.git.tag>>
     executor:
       name: ci-utils
       image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>
@@ -115,6 +119,7 @@ jobs:
     environment:
       REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>
       REGISTRY_REPO: "library/$CIRCLE_PROJECT_REPONAME"
+      TAG: <<pipeline.git.revision>>,<<pipeline.git.tag>>
     executor:
       name: ci-utils
       image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>
@@ -224,11 +229,10 @@ jobs:
       - image: harbor.k8s.libraries.psu.edu/library/solr:9.5.0
         environment:
           SOLR_STOP_WAIT: 1
-        command: [
-          "/bin/bash",
-          "-c",
-          "solr -c && solr auth enable -credentials catalog:catalog -z localhost:9983; solr stop && solr -c -f",
-        ]
+        command:
+          - /bin/bash
+          - -c
+          - "solr -c && solr auth enable -credentials catalog:catalog -z localhost:9983; solr stop && solr -c -f"
     environment:
       RAILS_ENV: test
       SETTINGS__solr__username: catalog

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# space separated list of users/teams will be requested for
+# review when someone opens a pull request. Syntax is the same
+# as with .gitignore. More info here:
+#   https://help.github.com/articles/about-codeowners/
+#
+# Global CODEOWNERS
+*  @psu-libraries/devops
+

--- a/.github/workflows/delete-branch-deployment.yml
+++ b/.github/workflows/delete-branch-deployment.yml
@@ -1,0 +1,17 @@
+name: Branch Deleted
+on: 
+  delete
+jobs:
+  delete-deployment:
+    if: contains(github.event.ref, 'preview/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI Pipeline
+        id: delete-deployment
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          # pass name of the branch deleted to CircleCI
+          GHA_Meta: "${{ github.event.ref }}"
+        env:
+          # CircleCI API token
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/.github/workflows/delete-branch-deployment.yml
+++ b/.github/workflows/delete-branch-deployment.yml
@@ -3,7 +3,7 @@ on:
   delete
 jobs:
   delete-deployment:
-    if: contains(github.event.ref, 'preview/')
+    if: contains(github.event.ref, 'update/') || contains(github.event.ref, 'preview/')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CircleCI Pipeline


### PR DESCRIPTION

**CI/CD Configuration Enhancements:**

* Added a new `CLUSTERS_ULPROD` parameter to `.circleci/config.yml` 
* Improved parameter usage and environment variable handling in CircleCI jobs, including using `$CONFIG_REPO_URL` for cloning and setting the `TAG` environment variable to include both the git revision and tag. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L52-R55) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R82-R87) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R123)
* Updated the Solr service command syntax in CircleCI jobs for better readability and maintainability.
* Renamed the workflow from `blacklight-delete-ci-cd` to `delete-deployment` for clarity.

**Repository Management and Automation:**

* Added a `.github/CODEOWNERS` file to assign default code ownership of the repository to the `@psu-libraries/devops` team.
* Introduced a new GitHub Actions workflow (`.github/workflows/delete-branch-deployment.yml`) that triggers a CircleCI pipeline to handle deployment deletions when branches matching `update/` or `preview/` are deleted.